### PR TITLE
feat: scaffold foundations — color tokens, types, mock data, components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-attributes"
+version = "0.1.0"
+source = "git+https://github.com/DioxusLabs/components#ccdb07f69383de008a0afadda0e5ab7ec14c1a9c"
+dependencies = [
+ "dioxus-rsx",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "dioxus-cli-config"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +886,7 @@ dependencies = [
  "global-hotkey",
  "infer",
  "jni 0.21.1",
- "lazy-js-bundle",
+ "lazy-js-bundle 0.7.4",
  "libc",
  "muda",
  "ndk",
@@ -944,7 +955,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "lazy-js-bundle",
+ "lazy-js-bundle 0.7.4",
  "serde",
  "serde_json",
  "tracing",
@@ -1103,7 +1114,7 @@ dependencies = [
  "futures-util",
  "generational-box",
  "keyboard-types",
- "lazy-js-bundle",
+ "lazy-js-bundle 0.7.4",
  "rustversion",
  "serde",
  "serde_json",
@@ -1133,7 +1144,7 @@ dependencies = [
  "dioxus-core-types",
  "dioxus-html",
  "js-sys",
- "lazy-js-bundle",
+ "lazy-js-bundle 0.7.4",
  "rustc-hash 2.1.1",
  "serde",
  "sledgehammer_bindgen",
@@ -1153,6 +1164,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-wasm",
+]
+
+[[package]]
+name = "dioxus-primitives"
+version = "0.0.1"
+source = "git+https://github.com/DioxusLabs/components#ccdb07f69383de008a0afadda0e5ab7ec14c1a9c"
+dependencies = [
+ "dioxus",
+ "dioxus-attributes",
+ "dioxus-sdk-time",
+ "lazy-js-bundle 0.6.2",
+ "num-integer",
+ "serde",
+ "time",
+ "tracing",
 ]
 
 [[package]]
@@ -1201,6 +1227,18 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "dioxus-sdk-time"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c25ae93a3f72e734873b97fbd09d9b1b6adff97205fb0ffd8543e3564fb78e"
+dependencies = [
+ "dioxus",
+ "futures",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -1263,7 +1301,7 @@ dependencies = [
  "generational-box",
  "gloo-timers",
  "js-sys",
- "lazy-js-bundle",
+ "lazy-js-bundle 0.7.4",
  "rustc-hash 2.1.1",
  "send_wrapper",
  "serde",
@@ -2458,6 +2496,12 @@ dependencies = [
 
 [[package]]
 name = "lazy-js-bundle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e49596223b9d9d4947a14a25c142a6e7d8ab3f27eb3ade269d238bb8b5c267e2"
+
+[[package]]
+name = "lazy-js-bundle"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60d7adc10cb9440d17fa67e467febdfc98931338773d11bfee81809af54d0697"
@@ -2882,6 +2926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,6 +2962,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4487,7 +4549,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4868,6 +4932,8 @@ dependencies = [
  "dioxus",
  "dioxus-core",
  "dioxus-free-icons",
+ "dioxus-primitives",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2021"
 dioxus = { version = "=0.7.3", features = ["router"] }
 dioxus-core = "=0.7.3"
 dioxus-free-icons = { version = "0.10", features = ["lucide"] }
+serde = { version = "1", features = ["derive"] }
+dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version = "0.0.1", default-features = false }
 
 [features]
 default = ["web"]

--- a/assets/dx-components-theme.css
+++ b/assets/dx-components-theme.css
@@ -1,0 +1,87 @@
+/* This file contains the global styles for the styled dioxus components. You only
+ * need to import this file once in your project root.
+ */
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
+
+body {
+  color: var(--secondary-color-4);
+  font-family: Inter, sans-serif;
+  font-optical-sizing: auto;
+  font-style: normal;
+  font-weight: 400;
+}
+
+html[data-theme="dark"] {
+  --dark: initial;
+  --light: ;
+}
+
+html[data-theme="light"] {
+  --dark: ;
+  --light: initial;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --dark: initial;
+    --light: ;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --dark: ;
+    --light: initial;
+  }
+}
+
+:root {
+  /* Primary colors */
+  --primary-color: var(--dark, #000) var(--light, #fff);
+  --primary-color-1: var(--dark, #0e0e0e) var(--light, #fbfbfb);
+  --primary-color-2: var(--dark, #0a0a0a) var(--light, #fff);
+  --primary-color-3: var(--dark, #141313) var(--light, #f8f8f8);
+  --primary-color-4: var(--dark, #1a1a1a) var(--light, #f8f8f8);
+  --primary-color-5: var(--dark, #262626) var(--light, #f5f5f5);
+  --primary-color-6: var(--dark, #232323) var(--light, #e5e5e5);
+  --primary-color-7: var(--dark, #3e3e3e) var(--light, #b0b0b0);
+
+  /* Secondary colors */
+  --secondary-color: var(--dark, #fff) var(--light, #000);
+  --secondary-color-1: var(--dark, #fafafa) var(--light, #000);
+  --secondary-color-2: var(--dark, #e6e6e6) var(--light, #0d0d0d);
+  --secondary-color-3: var(--dark, #dcdcdc) var(--light, #2b2b2b);
+  --secondary-color-4: var(--dark, #d4d4d4) var(--light, #111);
+  --secondary-color-5: var(--dark, #a1a1a1) var(--light, #848484);
+  --secondary-color-6: var(--dark, #5d5d5d) var(--light, #d0d0d0);
+
+  /* Highlight colors */
+  --focused-border-color: var(--dark, #2b7fff) var(--light, #2b7fff);
+  --primary-success-color: var(--dark, #02271c) var(--light, #ecfdf5);
+  --secondary-success-color: var(--dark, #b6fae3) var(--light, #10b981);
+  --primary-warning-color: var(--dark, #342203) var(--light, #fffbeb);
+  --secondary-warning-color: var(--dark, #feeac7) var(--light, #f59e0b);
+  --primary-error-color: var(--dark, #a22e2e) var(--light, #dc2626);
+  --secondary-error-color: var(--dark, #9b1c1c) var(--light, #ef4444);
+  --contrast-error-color: var(--dark, var(--secondary-color-3)) var(--light, var(--primary-color));
+  --primary-info-color: var(--dark, var(--primary-color-5)) var(--light, var(--primary-color));
+  --secondary-info-color: var(--dark, var(--primary-color-7)) var(--light, var(--secondary-color-3));
+}
+
+/* Modern browsers with `scrollbar-*` support */
+@supports (scrollbar-width: auto) {
+  :not(:hover) {
+    scrollbar-color: rgb(0 0 0 / 0%) rgb(0 0 0 / 0%);
+  }
+
+  :hover {
+    scrollbar-color: var(--secondary-color-2) rgb(0 0 0 / 0%);
+  }
+}
+
+/* Legacy browsers with `::-webkit-scrollbar-*` support */
+@supports selector(::-webkit-scrollbar) {
+  :root::-webkit-scrollbar-track {
+    background: transparent;
+  }
+}

--- a/input.css
+++ b/input.css
@@ -1,4 +1,32 @@
 @import "tailwindcss/preflight";
 @tailwind utilities;
 
-@plugin "daisyui";
+:root {
+  --background: #F5EFE6;
+  --foreground: #1C1917;
+  --card: #FFFFFF;
+  --card-foreground: #1C1917;
+  --primary: #1A6B72;
+  --primary-foreground: #FFFFFF;
+  --cta: #E87C4E;
+  --cta-foreground: #FFFFFF;
+  --accent: #7BB8C4;
+  --accent-foreground: #1C1917;
+  --muted: #78716C;
+  --border: #E7DDD4;
+}
+
+.dark {
+  --background: #0F1923;
+  --foreground: #F0EBE3;
+  --card: #1A2535;
+  --card-foreground: #F0EBE3;
+  --primary: #2DD4BF;
+  --primary-foreground: #0F1923;
+  --cta: #E87C4E;
+  --cta-foreground: #FFFFFF;
+  --accent: #7BB8C4;
+  --accent-foreground: #F0EBE3;
+  --muted: #8B9BA8;
+  --border: #2A3A4A;
+}

--- a/src/components/badge/component.rs
+++ b/src/components/badge/component.rs
@@ -1,0 +1,77 @@
+use dioxus::prelude::*;
+use dioxus_primitives::icon;
+
+#[derive(Copy, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub enum BadgeVariant {
+    #[default]
+    Primary,
+    Secondary,
+    Destructive,
+    Outline,
+}
+
+impl BadgeVariant {
+    pub fn class(&self) -> &'static str {
+        match self {
+            BadgeVariant::Primary => "primary",
+            BadgeVariant::Secondary => "secondary",
+            BadgeVariant::Destructive => "destructive",
+            BadgeVariant::Outline => "outline",
+        }
+    }
+}
+
+/// The props for the [`Badge`] component.
+#[derive(Props, Clone, PartialEq)]
+pub struct BadgeProps {
+    #[props(default)]
+    pub variant: BadgeVariant,
+
+    /// Additional attributes to extend the badge element
+    #[props(extends = GlobalAttributes)]
+    pub attributes: Vec<Attribute>,
+
+    /// The children of the badge element
+    pub children: Element,
+}
+
+#[component]
+pub fn Badge(props: BadgeProps) -> Element {
+    rsx! {
+        document::Link { rel: "stylesheet", href: asset!("./style.css") }
+
+        BadgeElement {
+            "padding": true,
+            variant: props.variant,
+            attributes: props.attributes,
+            {props.children}
+        }
+    }
+}
+
+#[component]
+fn BadgeElement(props: BadgeProps) -> Element {
+    rsx! {
+        span {
+            class: "badge",
+            "data-style": props.variant.class(),
+            ..props.attributes,
+            {props.children}
+        }
+    }
+}
+
+#[component]
+pub fn VerifiedIcon() -> Element {
+    rsx! {
+        // Badge icon from lucide https://lucide.dev/icons/badge-check
+        icon::Icon {
+            width: "12px",
+            height: "12px",
+            stroke: "var(--secondary-color-4)",
+            path { d: "M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" }
+            path { d: "m9 12 2 2 4-4" }
+        }
+    }
+}

--- a/src/components/badge/mod.rs
+++ b/src/components/badge/mod.rs
@@ -1,0 +1,2 @@
+mod component;
+pub use component::*;

--- a/src/components/badge/style.css
+++ b/src/components/badge/style.css
@@ -1,0 +1,42 @@
+.badge-example {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  min-width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  box-shadow: 0 0 0 1px var(--primary-color-2);
+  font-size: 12px;
+  gap: 4px
+}
+
+.badge[padding="true"] {
+  padding: 0 8px;
+}
+
+.badge[data-style="primary"] {
+  background-color: var(--secondary-color-2);
+  color: var(--primary-color);
+}
+
+.badge[data-style="secondary"] {
+  background-color: var(--primary-color-5);
+  color: var(--secondary-color-1);
+}
+
+.badge[data-style="outline"] {
+  border: 1px solid var(--primary-color-6);
+  background-color: var(--light, var(--primary-color)) var(--dark, var(--primary-color-3));
+  color: var(--secondary-color-4);
+}
+
+.badge[data-style="destructive"] {
+  background-color: var(--primary-error-color);
+  color: var(--contrast-error-color);
+}

--- a/src/components/button/component.rs
+++ b/src/components/button/component.rs
@@ -1,0 +1,68 @@
+use dioxus::prelude::*;
+use dioxus_primitives::dioxus_attributes::attributes;
+use dioxus_primitives::merge_attributes;
+
+#[derive(Copy, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub enum ButtonVariant {
+    #[default]
+    Primary,
+    Secondary,
+    Destructive,
+    Outline,
+    Ghost,
+}
+
+impl ButtonVariant {
+    pub fn class(&self) -> &'static str {
+        match self {
+            ButtonVariant::Primary => "primary",
+            ButtonVariant::Secondary => "secondary",
+            ButtonVariant::Destructive => "destructive",
+            ButtonVariant::Outline => "outline",
+            ButtonVariant::Ghost => "ghost",
+        }
+    }
+}
+
+#[component]
+pub fn Button(
+    #[props(default)] variant: ButtonVariant,
+    #[props(extends=GlobalAttributes)]
+    #[props(extends=button)]
+    attributes: Vec<Attribute>,
+    onclick: Option<EventHandler<MouseEvent>>,
+    onmousedown: Option<EventHandler<MouseEvent>>,
+    onmouseup: Option<EventHandler<MouseEvent>>,
+    children: Element,
+) -> Element {
+    let base = attributes!(button {
+        class: "button",
+        "data-style": variant.class(),
+    });
+    let merged = merge_attributes(vec![base, attributes]);
+
+    rsx! {
+        document::Link { rel: "stylesheet", href: asset!("./style.css") }
+
+        button {
+            onclick: move |event| {
+                if let Some(f) = &onclick {
+                    f.call(event);
+                }
+            },
+            onmousedown: move |event| {
+                if let Some(f) = &onmousedown {
+                    f.call(event);
+                }
+            },
+            onmouseup: move |event| {
+                if let Some(f) = &onmouseup {
+                    f.call(event);
+                }
+            },
+            ..merged,
+            {children}
+        }
+    }
+}

--- a/src/components/button/mod.rs
+++ b/src/components/button/mod.rs
@@ -1,0 +1,2 @@
+mod component;
+pub use component::*;

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -1,0 +1,60 @@
+.button {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.button:focus-visible {
+  box-shadow: 0 0 0 2px var(--focused-border-color);
+}
+
+.button[data-style="primary"] {
+  background-color: var(--secondary-color-2);
+  color: var(--primary-color);
+}
+
+.button[data-style="primary"]:hover {
+  background-color: var(--secondary-color-1);
+}
+
+.button[data-style="secondary"] {
+  background-color: var(--primary-color-5);
+  color: var(--secondary-color-1);
+}
+
+.button[data-style="secondary"]:hover {
+  background-color: var(--primary-color-4);
+}
+
+.button[data-style="ghost"] {
+  background-color: transparent;
+  color: var(--secondary-color-4);
+}
+
+.button[data-style="ghost"]:hover {
+  background-color: var(--primary-color-5);
+  color: var(--secondary-color-1);
+}
+
+.button[data-style="outline"] {
+  border: 1px solid var(--primary-color-6);
+  background-color: var(--light, var(--primary-color))
+    var(--dark, var(--primary-color-3));
+  color: var(--secondary-color-4);
+}
+
+.button[data-style="outline"]:hover {
+  background-color: var(--primary-color-4);
+}
+
+.button[data-style="destructive"] {
+  background-color: var(--primary-error-color);
+  color: var(--contrast-error-color);
+}
+
+.button[data-style="destructive"]:hover {
+  background-color: var(--secondary-error-color);
+}

--- a/src/components/card/component.rs
+++ b/src/components/card/component.rs
@@ -1,0 +1,107 @@
+use dioxus::prelude::*;
+
+#[component]
+pub fn Card(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        document::Link { rel: "stylesheet", href: asset!("./style.css") }
+        div {
+            class: "card",
+            "data-slot": "card",
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn CardHeader(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div {
+            class: "card-header",
+            "data-slot": "card-header",
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn CardTitle(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div {
+            class: "card-title",
+            "data-slot": "card-title",
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn CardDescription(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div {
+            class: "card-description",
+            "data-slot": "card-description",
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn CardAction(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div {
+            class: "card-action",
+            "data-slot": "card-action",
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn CardContent(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div {
+            class: "card-content",
+            "data-slot": "card-content",
+            ..attributes,
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn CardFooter(
+    #[props(extends=GlobalAttributes)] attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        div {
+            class: "card-footer",
+            "data-slot": "card-footer",
+            ..attributes,
+            {children}
+        }
+    }
+}

--- a/src/components/card/mod.rs
+++ b/src/components/card/mod.rs
@@ -1,0 +1,3 @@
+mod component;
+pub use component::*;
+

--- a/src/components/card/style.css
+++ b/src/components/card/style.css
@@ -1,0 +1,52 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 0;
+  border: 1px solid var(--light, var(--primary-color-6)) var(--dark, var(--primary-color-5));
+  border-radius: 1rem;
+  background-color: var(--light, var(--primary-color-2)) var(--dark, var(--primary-color-3));
+  box-shadow: 0 2px 10px rgb(0 0 0 / 10%);
+  color: var(--secondary-color-4);
+  gap: 1.5rem;
+}
+
+.card-header {
+  display: grid;
+  align-items: start;
+  padding: 0 1.5rem;
+  gap: 0.5rem;
+  grid-auto-rows: min-content;
+  grid-template-rows: auto auto;
+}
+
+.card-header:has([data-slot="card-action"]) {
+  grid-template-columns: 1fr auto;
+}
+
+.card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.card-description {
+  color: var(--secondary-color-5);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.card-action {
+  grid-column-start: 2;
+  grid-row: 1 / span 2;
+  place-self: start end;
+}
+
+.card-content {
+  padding: 0 1.5rem;
+}
+
+.card-footer {
+  display: flex;
+  align-items: center;
+  padding: 0 1.5rem;
+}

--- a/src/components/input/component.rs
+++ b/src/components/input/component.rs
@@ -1,0 +1,54 @@
+use dioxus::prelude::*;
+
+#[component]
+pub fn Input(
+    oninput: Option<EventHandler<FormEvent>>,
+    onchange: Option<EventHandler<FormEvent>>,
+    oninvalid: Option<EventHandler<FormEvent>>,
+    onselect: Option<EventHandler<SelectionEvent>>,
+    onselectionchange: Option<EventHandler<SelectionEvent>>,
+    onfocus: Option<EventHandler<FocusEvent>>,
+    onblur: Option<EventHandler<FocusEvent>>,
+    onfocusin: Option<EventHandler<FocusEvent>>,
+    onfocusout: Option<EventHandler<FocusEvent>>,
+    onkeydown: Option<EventHandler<KeyboardEvent>>,
+    onkeypress: Option<EventHandler<KeyboardEvent>>,
+    onkeyup: Option<EventHandler<KeyboardEvent>>,
+    oncompositionstart: Option<EventHandler<CompositionEvent>>,
+    oncompositionupdate: Option<EventHandler<CompositionEvent>>,
+    oncompositionend: Option<EventHandler<CompositionEvent>>,
+    oncopy: Option<EventHandler<ClipboardEvent>>,
+    oncut: Option<EventHandler<ClipboardEvent>>,
+    onpaste: Option<EventHandler<ClipboardEvent>>,
+    #[props(extends=GlobalAttributes)]
+    #[props(extends=input)]
+    attributes: Vec<Attribute>,
+    children: Element,
+) -> Element {
+    rsx! {
+        document::Link { rel: "stylesheet", href: asset!("./style.css") }
+        input {
+            class: "input",
+            oninput: move |e| _ = oninput.map(|callback| callback(e)),
+            onchange: move |e| _ = onchange.map(|callback| callback(e)),
+            oninvalid: move |e| _ = oninvalid.map(|callback| callback(e)),
+            onselect: move |e| _ = onselect.map(|callback| callback(e)),
+            onselectionchange: move |e| _ = onselectionchange.map(|callback| callback(e)),
+            onfocus: move |e| _ = onfocus.map(|callback| callback(e)),
+            onblur: move |e| _ = onblur.map(|callback| callback(e)),
+            onfocusin: move |e| _ = onfocusin.map(|callback| callback(e)),
+            onfocusout: move |e| _ = onfocusout.map(|callback| callback(e)),
+            onkeydown: move |e| _ = onkeydown.map(|callback| callback(e)),
+            onkeypress: move |e| _ = onkeypress.map(|callback| callback(e)),
+            onkeyup: move |e| _ = onkeyup.map(|callback| callback(e)),
+            oncompositionstart: move |e| _ = oncompositionstart.map(|callback| callback(e)),
+            oncompositionupdate: move |e| _ = oncompositionupdate.map(|callback| callback(e)),
+            oncompositionend: move |e| _ = oncompositionend.map(|callback| callback(e)),
+            oncopy: move |e| _ = oncopy.map(|callback| callback(e)),
+            oncut: move |e| _ = oncut.map(|callback| callback(e)),
+            onpaste: move |e| _ = onpaste.map(|callback| callback(e)),
+            ..attributes,
+            {children}
+        }
+    }
+}

--- a/src/components/input/mod.rs
+++ b/src/components/input/mod.rs
@@ -1,0 +1,2 @@
+mod component;
+pub use component::*;

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -1,0 +1,39 @@
+/* Input Styles */
+.input {
+  position: relative;
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 0.5rem;
+  border-radius: calc(0.5rem);
+  background: none;
+  background-color: var(--light, var(--primary-color)) var(--dark, color-mix(in oklab, #FFFFFF26 30%, transparent));
+  box-shadow: inset 0 0 0 1px var(--light, var(--primary-color-6))
+    var(--dark, var(--primary-color-7));
+  color: var(--secondary-color-4);
+  cursor: pointer;
+  gap: 0.25rem;
+  transition: background-color 100ms ease-out;
+}
+
+.input::placeholder {
+  color: var(--secondary-color-5);
+}
+
+.input:disabled {
+  color: var(--secondary-color-5);
+  cursor: not-allowed;
+}
+
+.input:hover:not(:disabled),
+.input:focus-visible {
+  background: var(--light, var(--primary-color-4))
+    var(--dark, color-mix(in oklab, #FFFFFF26 50%, transparent));
+  color: var(--secondary-color-1);
+  outline: none;
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -4,3 +4,7 @@
 
 mod hero;
 pub use hero::Hero;
+pub mod button;
+pub mod card;
+pub mod badge;
+pub mod input;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,67 +1,117 @@
-// The dioxus prelude contains a ton of common items used in dioxus apps. It's a good idea to import wherever you
-// need dioxus
 use dioxus::prelude::*;
 
 use components::Hero;
 use views::{Blog, Home, Navbar};
 
-/// Define a components module that contains all shared components for our app.
 mod components;
-/// Define a views module that contains the UI for all Layouts and Routes for our app.
+mod types;
 mod views;
 
-/// The Route enum is used to define the structure of internal routes in our app. All route enums need to derive
-/// the [`Routable`] trait, which provides the necessary methods for the router to work.
-/// 
-/// Each variant represents a different URL pattern that can be matched by the router. If that pattern is matched,
-/// the components for that route will be rendered.
+use types::*;
+
+pub static EMAILS: GlobalSignal<Vec<Email>> = Signal::global(|| seed_emails());
+pub static TRIPS: GlobalSignal<Vec<Trip>> = Signal::global(|| seed_trips());
+pub static SELECTED_EMAIL: GlobalSignal<Option<String>> = Signal::global(|| None);
+pub static SELECTED_TRIP: GlobalSignal<Option<String>> = Signal::global(|| None);
+
+fn seed_emails() -> Vec<Email> {
+    vec![
+        Email {
+            id: "e1".into(),
+            subject: "Flight Confirmation: DL-442 Boise to Orlando".into(),
+            sender: "Delta Air Lines".into(),
+            sender_email: "noreply@delta.com".into(),
+            date: "Mar 15, 2026".into(),
+            body_preview: "Thank you for booking with Delta. Your confirmation number is XKRT72. Flight DL-442 departs Boise (BOI) on June 14 at 8:00 AM...".into(),
+            category: Category::Flight,
+            trip_id: Some("t1".into()),
+        },
+        Email {
+            id: "e2".into(),
+            subject: "Your Reservation at Disney's Polynesian Resort".into(),
+            sender: "Disney Resort".into(),
+            sender_email: "reservations@disney.com".into(),
+            date: "Mar 16, 2026".into(),
+            body_preview: "Your reservation is confirmed. Check-in: June 14, 2026. Check-out: June 18, 2026. Confirmation: WDW-88432...".into(),
+            category: Category::Hotel,
+            trip_id: Some("t1".into()),
+        },
+        Email {
+            id: "e3".into(),
+            subject: "Carnival Cruise Booking Confirmation — Horizon".into(),
+            sender: "Carnival Cruise Line".into(),
+            sender_email: "noreply@carnival.com".into(),
+            date: "Feb 10, 2026".into(),
+            body_preview: "Thank you for booking Carnival Horizon. Embarkation: Port Canaveral, June 18, 2026 at 12:00 PM. Booking ID: CCL-99201...".into(),
+            category: Category::Cruise,
+            trip_id: Some("t2".into()),
+        },
+        Email {
+            id: "e4".into(),
+            subject: "Your United Airlines eTicket Receipt".into(),
+            sender: "United Airlines".into(),
+            sender_email: "noreply@united.com".into(),
+            date: "Mar 20, 2026".into(),
+            body_preview: "E-ticket receipt for UA-2241 Chicago to Boise. Confirmation: UA-XK881...".into(),
+            category: Category::Flight,
+            trip_id: None,
+        },
+        Email {
+            id: "e5".into(),
+            subject: "Marriott Bonvoy: Reservation Confirmed".into(),
+            sender: "Marriott Hotels".into(),
+            sender_email: "noreply@marriott.com".into(),
+            date: "Mar 21, 2026".into(),
+            body_preview: "Your stay at Chicago Marriott Downtown is confirmed. Check-in: Aug 5, 2026. Confirmation: MRRT-2091...".into(),
+            category: Category::Hotel,
+            trip_id: None,
+        },
+    ]
+}
+
+fn seed_trips() -> Vec<Trip> {
+    vec![
+        Trip {
+            id: "t1".into(),
+            name: "2026 Disney Family Trip".into(),
+            date_range: "Jun 14 – Jun 18, 2026".into(),
+            email_count: 2,
+            confirmed_count: 2,
+        },
+        Trip {
+            id: "t2".into(),
+            name: "2026 Caribbean Cruise".into(),
+            date_range: "Jun 18 – Jun 25, 2026".into(),
+            email_count: 1,
+            confirmed_count: 1,
+        },
+    ]
+}
+
 #[derive(Debug, Clone, Routable, PartialEq)]
 #[rustfmt::skip]
 enum Route {
-    // The layout attribute defines a wrapper for all routes under the layout. Layouts are great for wrapping
-    // many routes with a common UI like a navbar.
     #[layout(Navbar)]
-        // The route attribute defines the URL pattern that a specific route matches. If that pattern matches the URL,
-        // the component for that route will be rendered. The component name that is rendered defaults to the variant name.
         #[route("/")]
         Home {},
-        // The route attribute can include dynamic parameters that implement [`std::str::FromStr`] and [`std::fmt::Display`] with the `:` syntax.
-        // In this case, id will match any integer like `/blog/123` or `/blog/-456`.
         #[route("/blog/:id")]
-        // Fields of the route variant will be passed to the component as props. In this case, the blog component must accept
-        // an `id` prop of type `i32`.
         Blog { id: i32 },
 }
 
-// We can import assets in dioxus with the `asset!` macro. This macro takes a path to an asset relative to the crate root.
-// The macro returns an `Asset` type that will display as the path to the asset in the browser or a local path in desktop bundles.
 const FAVICON: Asset = asset!("/assets/favicon.ico");
-// The asset macro also minifies some assets like CSS and JS to make bundled smaller
 const MAIN_CSS: Asset = asset!("/assets/styling/main.css");
 const TAILWIND_CSS: Asset = asset!("/assets/tailwind.css");
 
 fn main() {
-    // The `launch` function is the main entry point for a dioxus app. It takes a component and renders it with the platform feature
-    // you have enabled
     dioxus::launch(App);
 }
 
-/// App is the main component of our app. Components are the building blocks of dioxus apps. Each component is a function
-/// that takes some props and returns an Element. In this case, App takes no props because it is the root of our app.
-///
-/// Components should be annotated with `#[component]` to support props, better error messages, and autocomplete
 #[component]
 fn App() -> Element {
-    // The `rsx!` macro lets us define HTML inside of rust. It expands to an Element with all of our HTML inside.
     rsx! {
-        // In addition to element and text (which we will see later), rsx can contain other components. In this case,
-        // we are using the `document::Link` component to add a link to our favicon and main CSS file into the head of our app.
         document::Link { rel: "icon", href: FAVICON }
         document::Link { rel: "stylesheet", href: MAIN_CSS }
         document::Link { rel: "stylesheet", href: TAILWIND_CSS }
-
-        // The router component renders the route enum we defined above. It will handle synchronization of the URL and render
-        // the layouts and components for the active route.
         Router::<Route> {}
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Category {
+    Flight,
+    Hotel,
+    CarRental,
+    Cruise,
+    Activity,
+    Other,
+}
+
+impl Category {
+    pub fn label(&self) -> &str {
+        match self {
+            Category::Flight => "✈️ Flight",
+            Category::Hotel => "🏨 Hotel",
+            Category::CarRental => "🚗 Car Rental",
+            Category::Cruise => "🚢 Cruise",
+            Category::Activity => "🎡 Activity",
+            Category::Other => "📧 Other",
+        }
+    }
+    pub fn color_class(&self) -> &str {
+        match self {
+            Category::Flight => "text-accent",
+            Category::Hotel => "text-cta",
+            Category::CarRental => "text-muted",
+            Category::Cruise => "text-primary",
+            Category::Activity => "text-accent",
+            Category::Other => "text-muted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ItineraryStatus {
+    Confirmed,
+    Pending,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Email {
+    pub id: String,
+    pub subject: String,
+    pub sender: String,
+    pub sender_email: String,
+    pub date: String,
+    pub body_preview: String,
+    pub category: Category,
+    pub trip_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Trip {
+    pub id: String,
+    pub name: String,
+    pub date_range: String,
+    pub email_count: usize,
+    pub confirmed_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ItineraryItem {
+    pub id: String,
+    pub trip_id: String,
+    pub email_id: String,
+    pub title: String,
+    pub detail: String,
+    pub sub_detail: Option<String>,
+    pub date: String,
+    pub category: Category,
+    pub status: ItineraryStatus,
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,33 @@ module.exports = {
   mode: "all",
   content: ["./src/**/*.{rs,html,css}", "./dist/**/*.html"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        card: {
+          DEFAULT: "var(--card)",
+          foreground: "var(--card-foreground)",
+        },
+        primary: {
+          DEFAULT: "var(--primary)",
+          foreground: "var(--primary-foreground)",
+        },
+        cta: {
+          DEFAULT: "var(--cta)",
+          foreground: "var(--cta-foreground)",
+        },
+        accent: {
+          DEFAULT: "var(--accent)",
+          foreground: "var(--accent-foreground)",
+        },
+        muted: "var(--muted)",
+        border: "var(--border)",
+      },
+      borderColor: {
+        DEFAULT: "var(--border)",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
Implements [#1 — Scaffold Foundations](https://github.com/zachatrocity/voyage/issues/1). This is the base layer all other scaffold screens depend on.

## What's in here
- **Color tokens** — Light + dark CSS custom properties in `input.css`, wired into `tailwind.config.js` (`bg-background`, `text-foreground`, `bg-card`, `bg-primary`, `bg-cta`, `text-muted`, etc.)
- **dx components** — `button`, `card`, `badge`, `input` installed via `dx components add` (scroll-area not in registry, skipped)
- **`src/types.rs`** — `Email`, `Trip`, `Category`, `ItineraryStatus`, `ItineraryItem` with serde derives
- **`src/main.rs`** — `GlobalSignal`s (`EMAILS`, `TRIPS`, `SELECTED_EMAIL`, `SELECTED_TRIP`) seeded with realistic mock data (5 emails, 2 trips)
- **Build verified** — `dx build --platform web` compiles clean

## Design Reference
Color palette from `Projects/Voyage UI Design/` in Obsidian (wanderlust light + dark).

Closes #1