### PR TITLE
feat: scaffold email list screen — search, filters, email cards

### DIFF
--- a/src/components/discovery_banner.rs
+++ b/src/components/discovery_banner.rs
@@ -1,0 +1,19 @@
+use dioxus::prelude::*;
+
+#[component]
+pub fn DiscoveryBanner(count: usize) -> Element {
+    if count == 0 {
+        return rsx! {};
+    }
+
+    rsx! {
+        div { class: "mx-4 mb-2 rounded-xl bg-primary/10 border border-primary/30 px-4 py-3 flex items-center justify-between",
+            span { class: "text-sm text-primary font-medium",
+                "We found {count} travel emails — review?"
+            }
+            button { class: "text-xs bg-cta text-white px-3 py-1.5 rounded-full font-medium",
+                "Review"
+            }
+        }
+    }
+}

--- a/src/components/email_list_item.rs
+++ b/src/components/email_list_item.rs
@@ -1,0 +1,66 @@
+use dioxus::prelude::*;
+
+use crate::types::{Category, Email};
+use crate::TRIPS;
+
+fn category_emoji(cat: &Category) -> &'static str {
+    match cat {
+        Category::Flight => "✈️",
+        Category::Hotel => "🏨",
+        Category::CarRental => "🚗",
+        Category::Cruise => "🚢",
+        Category::Activity => "🎡",
+        Category::Other => "📧",
+    }
+}
+
+#[component]
+pub fn EmailListItem(email: Email, on_click: EventHandler<String>) -> Element {
+    let id = email.id.clone();
+    let trip_label = email.trip_id.as_ref().and_then(|tid| {
+        TRIPS.read().iter().find(|t| &t.id == tid).map(|t| t.name.clone())
+    });
+
+    rsx! {
+        div {
+            class: "mx-4 mb-2 bg-card rounded-xl shadow-sm px-4 py-3 flex items-center gap-3 cursor-pointer",
+            onclick: move |_| on_click.call(id.clone()),
+
+            // Left: category emoji circle
+            div { class: "w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0 text-lg",
+                "{category_emoji(&email.category)}"
+            }
+
+            // Middle: subject + sender/date
+            div { class: "flex-1 min-w-0",
+                div { class: "text-sm font-semibold text-foreground truncate",
+                    "{email.subject}"
+                }
+                div { class: "flex justify-between items-center mt-0.5",
+                    span { class: "text-xs text-muted truncate",
+                        "{email.sender}"
+                    }
+                    span { class: "text-xs text-muted shrink-0 ml-2",
+                        "{email.date}"
+                    }
+                }
+            }
+
+            // Right: category badge + trip label
+            div { class: "flex flex-col items-end gap-1 shrink-0",
+                span { class: "text-xs border rounded-full px-2 py-0.5 {email.category.color_class()} border-current",
+                    "{email.category.label()}"
+                }
+                if let Some(label) = &trip_label {
+                    span { class: "bg-primary/10 text-primary text-xs rounded-full px-2 py-0.5",
+                        "{label}"
+                    }
+                } else {
+                    span { class: "border border-border text-muted text-xs rounded-full px-2 py-0.5",
+                        "Unlabeled"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/components/filter_chips.rs
+++ b/src/components/filter_chips.rs
@@ -1,0 +1,30 @@
+use dioxus::prelude::*;
+
+const FILTERS: &[&str] = &["All", "Flights ✈️", "Hotels 🏨", "Car Rental 🚗", "Cruises 🚢", "Other"];
+
+#[component]
+pub fn FilterChips(active: String, on_change: EventHandler<String>) -> Element {
+    rsx! {
+        div { class: "flex gap-2 px-4 overflow-x-auto pb-2 scrollbar-hide",
+            for filter in FILTERS.iter() {
+                {
+                    let is_active = active == *filter;
+                    let class = if is_active {
+                        "bg-primary text-white rounded-full px-3 py-1 text-sm whitespace-nowrap cursor-pointer"
+                    } else {
+                        "border border-border text-muted rounded-full px-3 py-1 text-sm bg-card whitespace-nowrap cursor-pointer"
+                    };
+                    let label = filter.to_string();
+                    let label2 = label.clone();
+                    rsx! {
+                        button {
+                            class: "{class}",
+                            onclick: move |_| on_change.call(label.clone()),
+                            "{label2}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -8,3 +8,7 @@ pub mod button;
 pub mod card;
 pub mod badge;
 pub mod input;
+pub mod search_bar;
+pub mod filter_chips;
+pub mod discovery_banner;
+pub mod email_list_item;

--- a/src/components/search_bar.rs
+++ b/src/components/search_bar.rs
@@ -1,0 +1,20 @@
+use dioxus::prelude::*;
+use dioxus_free_icons::icons::ld_icons::LdSearch;
+use dioxus_free_icons::Icon;
+
+#[component]
+pub fn SearchBar(value: String, on_change: EventHandler<String>) -> Element {
+    rsx! {
+        div { class: "px-4 pt-3 pb-2",
+            div { class: "flex items-center gap-2 bg-card rounded-xl px-3 py-2.5 border border-border",
+                Icon { icon: LdSearch, width: 16, height: 16, class: "text-muted shrink-0" }
+                input {
+                    class: "flex-1 bg-transparent text-sm text-foreground placeholder:text-muted outline-none",
+                    placeholder: "Search travel emails...",
+                    value: "{value}",
+                    oninput: move |e| on_change.call(e.value()),
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use components::Hero;
-use views::{Blog, Home, Navbar};
+use views::{Blog, EmailList, Home, Navbar};
 
 mod components;
 mod types;
@@ -96,6 +96,8 @@ enum Route {
         Home {},
         #[route("/blog/:id")]
         Blog { id: i32 },
+        #[route("/emails")]
+        EmailList {},
 }
 
 const FAVICON: Asset = asset!("/assets/favicon.ico");

--- a/src/views/email_list.rs
+++ b/src/views/email_list.rs
@@ -1,0 +1,105 @@
+use dioxus::prelude::*;
+use dioxus_free_icons::icons::ld_icons::{LdArrowLeft, LdMail, LdMap, LdSettings};
+use dioxus_free_icons::Icon;
+
+use crate::components::discovery_banner::DiscoveryBanner;
+use crate::components::email_list_item::EmailListItem;
+use crate::components::filter_chips::FilterChips;
+use crate::components::search_bar::SearchBar;
+use crate::types::Category;
+use crate::{EMAILS, SELECTED_EMAIL};
+
+#[component]
+pub fn EmailList() -> Element {
+    let mut search = use_signal(|| String::new());
+    let mut active_filter = use_signal(|| "All".to_string());
+
+    let filtered = use_memo(move || {
+        let emails = EMAILS.read();
+        emails
+            .iter()
+            .filter(|e| {
+                let q = search().to_lowercase();
+                let matches_search = q.is_empty()
+                    || e.subject.to_lowercase().contains(&q)
+                    || e.sender.to_lowercase().contains(&q);
+                let matches_filter = match active_filter().as_str() {
+                    "Flights ✈️" => e.category == Category::Flight,
+                    "Hotels 🏨" => e.category == Category::Hotel,
+                    "Car Rental 🚗" => e.category == Category::CarRental,
+                    "Cruises 🚢" => e.category == Category::Cruise,
+                    "Other" => e.category == Category::Other || e.category == Category::Activity,
+                    _ => true, // "All"
+                };
+                matches_search && matches_filter
+            })
+            .cloned()
+            .collect::<Vec<_>>()
+    });
+
+    let unreviewed_count = use_memo(move || {
+        EMAILS.read().iter().filter(|e| e.trip_id.is_none()).count()
+    });
+
+    rsx! {
+        div { class: "flex flex-col h-screen bg-background",
+            // Header
+            div { class: "bg-card border-b border-border px-4 py-3 flex items-center gap-3",
+                button { class: "text-muted",
+                    Icon { icon: LdArrowLeft, width: 20, height: 20 }
+                }
+                span { class: "text-lg font-semibold text-foreground flex-1",
+                    "Voyage ✈️"
+                }
+            }
+
+            SearchBar {
+                value: search(),
+                on_change: move |v: String| search.set(v),
+            }
+
+            DiscoveryBanner { count: unreviewed_count() }
+
+            FilterChips {
+                active: active_filter(),
+                on_change: move |v: String| active_filter.set(v),
+            }
+
+            // Email list
+            div { class: "flex-1 overflow-y-auto py-2 pb-24",
+                for email in filtered().iter() {
+                    EmailListItem {
+                        key: "{email.id}",
+                        email: email.clone(),
+                        on_click: move |id: String| {
+                            *SELECTED_EMAIL.write() = Some(id);
+                        },
+                    }
+                }
+
+                if filtered().is_empty() {
+                    div { class: "flex flex-col items-center justify-center py-12 text-muted",
+                        span { class: "text-4xl mb-2", "📭" }
+                        span { class: "text-sm", "No emails match your search" }
+                    }
+                }
+            }
+
+            // Bottom nav bar
+            div { class: "fixed bottom-0 left-0 right-0 bg-card border-t border-border px-6 py-2 flex justify-around items-center",
+                button { class: "flex flex-col items-center gap-0.5 text-primary",
+                    Icon { icon: LdMail, width: 20, height: 20 }
+                    span { class: "text-xs font-medium", "Emails" }
+                }
+                button { class: "flex flex-col items-center gap-0.5 text-muted",
+                    Icon { icon: LdMap, width: 20, height: 20 }
+                    span { class: "text-xs", "Trips" }
+                }
+                button { class: "flex flex-col items-center gap-0.5 text-muted",
+                    Icon { icon: LdSettings, width: 20, height: 20 }
+                    span { class: "text-xs", "Settings" }
+                }
+            }
+        }
+    }
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -16,3 +16,6 @@ pub use blog::Blog;
 
 mod navbar;
 pub use navbar::Navbar;
+
+mod email_list;
+pub use email_list::EmailList;


### PR DESCRIPTION
## Summary
Implements [#3 — Scaffold Email List](https://github.com/zachatrocity/voyage/issues/3).

## What's in here
- **SearchBar** — full-width search input with icon, reactive filtering
- **FilterChips** — horizontal scroll: All, Flights ✈️, Hotels 🏨, Car Rental 🚗, Cruises 🚢, Other
- **DiscoveryBanner** — shows count of untagged travel emails with Review CTA
- **EmailListItem** — card with category emoji circle, subject, sender/date, category badge, trip label chip (or ghost Unlabeled)
- **Email List view** at `/emails` — reads from `EMAILS` GlobalSignal, reactive search + filter
- Light/dark theme via CSS custom properties

Closes #3