### PR TITLE
fix: remove old top navbar, wire BottomNavBar with real route navigation

### DIFF
--- a/src/components/bottom_nav.rs
+++ b/src/components/bottom_nav.rs
@@ -1,33 +1,40 @@
+use crate::Route;
 use dioxus::prelude::*;
 use dioxus_free_icons::icons::ld_icons::{LdHome, LdMail, LdMap, LdSettings};
 use dioxus_free_icons::Icon;
 
 #[component]
-fn NavItem(id: &'static str, label: &'static str, active_tab: String, children: Element) -> Element {
-    let color_class = if active_tab == id { "text-primary" } else { "text-muted" };
-    rsx! {
-        div { class: "flex flex-col items-center gap-1 {color_class}",
-            {children}
-            span { class: "text-xs", "{label}" }
-        }
-    }
-}
-
-#[component]
 pub fn BottomNavBar(active_tab: String) -> Element {
+    let home_class = if active_tab == "home" { "text-primary" } else { "text-muted" };
+    let emails_class = if active_tab == "emails" { "text-primary" } else { "text-muted" };
+    let trips_class = if active_tab == "trips" { "text-primary" } else { "text-muted" };
+    let settings_class = if active_tab == "settings" { "text-primary" } else { "text-muted" };
+
     rsx! {
-        div { class: "fixed bottom-0 left-0 right-0 flex justify-around items-center h-16 bg-card border-t border-border",
-            NavItem { id: "home", label: "Home", active_tab: active_tab.clone(),
+        div { class: "fixed bottom-0 left-0 right-0 flex justify-around items-center h-16 bg-card border-t border-border z-50",
+            Link {
+                to: Route::Home {},
+                class: "flex flex-col items-center gap-1 {home_class}",
                 Icon { icon: LdHome, width: 20, height: 20 }
+                span { class: "text-xs", "Home" }
             }
-            NavItem { id: "emails", label: "Emails", active_tab: active_tab.clone(),
+            Link {
+                to: Route::EmailList {},
+                class: "flex flex-col items-center gap-1 {emails_class}",
                 Icon { icon: LdMail, width: 20, height: 20 }
+                span { class: "text-xs", "Emails" }
             }
-            NavItem { id: "trips", label: "Trips", active_tab: active_tab.clone(),
+            Link {
+                to: Route::Itinerary {},
+                class: "flex flex-col items-center gap-1 {trips_class}",
                 Icon { icon: LdMap, width: 20, height: 20 }
+                span { class: "text-xs", "Trips" }
             }
-            NavItem { id: "settings", label: "Settings", active_tab: active_tab.clone(),
+            Link {
+                to: Route::Home {},
+                class: "flex flex-col items-center gap-1 {settings_class}",
                 Icon { icon: LdSettings, width: 20, height: 20 }
+                span { class: "text-xs", "Settings" }
             }
         }
     }

--- a/src/views/navbar.rs
+++ b/src/views/navbar.rs
@@ -1,32 +1,11 @@
 use crate::Route;
 use dioxus::prelude::*;
 
-const NAVBAR_CSS: Asset = asset!("/assets/styling/navbar.css");
-
-/// The Navbar component that will be rendered on all pages of our app since every page is under the layout.
-///
-///
-/// This layout component wraps the UI of [Route::Home] and [Route::Blog] in a common navbar. The contents of the Home and Blog
-/// routes will be rendered under the outlet inside this component
+/// Layout wrapper — renders child routes via Outlet.
+/// Navigation is handled by BottomNavBar in each view.
 #[component]
 pub fn Navbar() -> Element {
     rsx! {
-        document::Link { rel: "stylesheet", href: NAVBAR_CSS }
-
-        div {
-            id: "navbar",
-            Link {
-                to: Route::Home {},
-                "Home"
-            }
-            Link {
-                to: Route::Blog { id: 1 },
-                "Trips"
-            }
-        }
-
-        // The `Outlet` component is used to render the next component inside the layout. In this case, it will render either
-        // the [`Home`] or [`Blog`] component depending on the current route.
         Outlet::<Route> {}
     }
 }


### PR DESCRIPTION
## Changes
- **`src/views/navbar.rs`** — stripped to bare `Outlet` wrapper, removes the old "Home | Trips" link bar
- **`src/components/bottom_nav.rs`** — replaced plain `div` nav items with Dioxus `Link` components wired to real routes

## Nav routing
| Tab | Route |
|-----|-------|
| Home | `Route::Home` |
| Emails | `Route::EmailList` |
| Trips | `Route::Itinerary` |
| Settings | `Route::Home` *(placeholder until settings screen exists)* |