### PR TITLE
feat: global toast notification system (#23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,6 +4933,7 @@ dependencies = [
  "dioxus-core",
  "dioxus-free-icons",
  "dioxus-primitives",
+ "gloo-timers",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ dioxus-core = "=0.7.3"
 dioxus-free-icons = { version = "0.10", features = ["lucide"] }
 serde = { version = "1", features = ["derive"] }
 dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version = "0.0.1", default-features = false }
+gloo-timers = { version = "0.3", features = ["futures"] }
 
 [features]
 default = ["web"]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -20,3 +20,5 @@ pub mod search_bar;
 pub mod filter_chips;
 pub mod discovery_banner;
 pub mod email_list_item;
+pub mod toast;
+pub use toast::Toast;

--- a/src/components/toast.rs
+++ b/src/components/toast.rs
@@ -1,0 +1,40 @@
+use dioxus::prelude::*;
+
+use crate::notification::{NotificationKind, NOTIFICATION};
+
+#[component]
+pub fn Toast() -> Element {
+    let notification = NOTIFICATION();
+
+    // Auto-dismiss after 4 seconds whenever a notification appears
+    use_effect(move || {
+        if NOTIFICATION().is_some() {
+            spawn(async move {
+                gloo_timers::future::TimeoutFuture::new(4_000).await;
+                *NOTIFICATION.write() = None;
+            });
+        }
+    });
+
+    match notification {
+        Some(notif) => {
+            let bg_class = match notif.kind {
+                NotificationKind::Error => "bg-cta",
+                NotificationKind::Success => "bg-green-600",
+                NotificationKind::Info => "bg-primary",
+            };
+
+            rsx! {
+                div { class: "fixed bottom-20 left-1/2 -translate-x-1/2 z-50 {bg_class} text-white rounded-xl shadow-lg px-4 py-3 flex flex-row items-center gap-3 max-w-sm",
+                    span { class: "flex-1 text-sm", "{notif.message}" }
+                    button {
+                        class: "text-white opacity-80 hover:opacity-100 font-bold text-lg leading-none",
+                        onclick: move |_| { *NOTIFICATION.write() = None; },
+                        "\u{00D7}"
+                    }
+                }
+            }
+        }
+        None => rsx! {},
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use dioxus::prelude::*;
 
+use components::Toast;
 use views::{EmailDetail, EmailList, Home, Itinerary, Navbar};
 
 mod components;
+pub mod notification;
 mod types;
 mod views;
 
@@ -173,6 +175,7 @@ fn App() -> Element {
         }
         div { class: "min-h-screen w-full bg-background text-foreground",
             Router::<Route> {}
+            Toast {}
         }
     }
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,0 +1,37 @@
+use dioxus::prelude::*;
+
+#[derive(Clone, PartialEq)]
+pub enum NotificationKind {
+    Error,
+    Success,
+    Info,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct AppNotification {
+    pub message: String,
+    pub kind: NotificationKind,
+}
+
+pub static NOTIFICATION: GlobalSignal<Option<AppNotification>> = Signal::global(|| None);
+
+pub fn notify_error(msg: impl Into<String>) {
+    *NOTIFICATION.write() = Some(AppNotification {
+        message: msg.into(),
+        kind: NotificationKind::Error,
+    });
+}
+
+pub fn notify_success(msg: impl Into<String>) {
+    *NOTIFICATION.write() = Some(AppNotification {
+        message: msg.into(),
+        kind: NotificationKind::Success,
+    });
+}
+
+pub fn notify_info(msg: impl Into<String>) {
+    *NOTIFICATION.write() = Some(AppNotification {
+        message: msg.into(),
+        kind: NotificationKind::Info,
+    });
+}


### PR DESCRIPTION
Closes #23

## Summary
- Adds `src/notification.rs` with `GlobalSignal<Option<AppNotification>>` and helper functions (`notify_error`, `notify_success`, `notify_info`)
- Adds `src/components/toast.rs` — fixed-position toast component (bottom-center, above nav) with auto-dismiss after 4s and manual X close
- Colors by kind: Error=bg-cta, Success=bg-green-600, Info=bg-primary
- Wired into App component in main.rs

## Test plan
- [ ] `dx serve --platform web` and call `notify_error("test")` from any component
- [ ] Verify toast appears bottom-center, auto-dismisses after 4s
- [ ] Verify X button dismisses immediately
- [ ] Verify each kind (Error/Success/Info) shows correct color

🤖 Generated with [Claude Code](https://claude.com/claude-code)