### PR TITLE
ci: restore shared debug keystore for consistent APK signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
           tar -xzf /tmp/dx.tar.gz -C /usr/local/bin
           dx --version
 
+      - name: Restore debug keystore
+        if: ${{ env.DEBUG_KEYSTORE != '' }}
+        env:
+          DEBUG_KEYSTORE: ${{ secrets.DEBUG_KEYSTORE }}
+        run: |
+          mkdir -p ~/.android
+          echo "$DEBUG_KEYSTORE" | base64 -d > ~/.android/debug.keystore
+
       - name: Build debug APK (arm64)
         run: dx build --platform android --target aarch64-linux-android
 


### PR DESCRIPTION
Decodes `DEBUG_KEYSTORE` secret into `~/.android/debug.keystore` before building so CI-built APKs have the same signature as local builds.

Fixes 'App not installed' errors when updating without uninstalling.

**Setup:** Add `DEBUG_KEYSTORE` repo secret (base64-encoded keystore).