### PR TITLE
feat: wire EmailList to real API using generated client (#16)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use crate::voyage_api::types::NotmuchEmailResult;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -58,6 +59,40 @@ pub struct Trip {
     pub date_range: String,
     pub email_count: usize,
     pub confirmed_count: usize,
+}
+
+impl From<NotmuchEmailResult> for Email {
+    fn from(r: NotmuchEmailResult) -> Self {
+        let from_str = r.from.unwrap_or_default();
+        // Backend "from" field is "Name <email@example.com>" — split it
+        let (sender, sender_email) = if let Some(start) = from_str.find('<') {
+            let name = from_str[..start].trim().to_string();
+            let email = from_str[start + 1..].trim_end_matches('>').to_string();
+            (if name.is_empty() { email.clone() } else { name }, email)
+        } else {
+            (from_str.clone(), from_str.clone())
+        };
+
+        let category = match r.category.as_deref().unwrap_or("other") {
+            "flight" => Category::Flight,
+            "hotel" => Category::Hotel,
+            "car_rental" => Category::CarRental,
+            "cruise" => Category::Cruise,
+            "activity" => Category::Activity,
+            _ => Category::Other,
+        };
+
+        Self {
+            id: r.message_id.unwrap_or_default(),
+            subject: r.subject.unwrap_or_default(),
+            sender,
+            sender_email,
+            date: r.date.unwrap_or_default(),
+            body_preview: r.body_preview.unwrap_or_default(),
+            category,
+            trip_id: r.trip_id,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/views/email_list.rs
+++ b/src/views/email_list.rs
@@ -6,40 +6,61 @@ use crate::components::discovery_banner::DiscoveryBanner;
 use crate::components::email_list_item::EmailListItem;
 use crate::components::filter_chips::FilterChips;
 use crate::components::search_bar::SearchBar;
-use crate::types::Category;
-use crate::{EMAILS, SELECTED_EMAIL};
+use crate::notification::notify_error;
+use crate::types::{Category, Email};
+use crate::voyage_client;
+use crate::SELECTED_EMAIL;
 
 #[component]
 pub fn EmailList() -> Element {
     let mut search = use_signal(|| String::new());
     let mut active_filter = use_signal(|| "All".to_string());
 
-    let filtered = use_memo(move || {
-        let emails = EMAILS.read();
-        emails
-            .iter()
-            .filter(|e| {
-                let q = search().to_lowercase();
-                let matches_search = q.is_empty()
-                    || e.subject.to_lowercase().contains(&q)
-                    || e.sender.to_lowercase().contains(&q);
-                let matches_filter = match active_filter().as_str() {
-                    "Flights ✈️" => e.category == Category::Flight,
-                    "Hotels 🏨" => e.category == Category::Hotel,
-                    "Car Rental 🚗" => e.category == Category::CarRental,
-                    "Cruises 🚢" => e.category == Category::Cruise,
-                    "Other" => e.category == Category::Other || e.category == Category::Activity,
-                    _ => true, // "All"
-                };
-                matches_search && matches_filter
-            })
-            .cloned()
-            .collect::<Vec<_>>()
+    // Fetch emails from API, reactive on search query
+    let email_resource = use_resource(move || {
+        let query = search().clone();
+        async move {
+            let client = match voyage_client::get_client() {
+                Ok(c) => c,
+                Err(e) => {
+                    notify_error(format!("Config error: {e}"));
+                    return Vec::new();
+                }
+            };
+            // Backend requires non-empty q param
+            let q = if query.is_empty() { "*".to_string() } else { query };
+            match client.search_emails(Some("50"), &q, None::<&str>).await {
+                Ok(resp) => {
+                    resp.into_inner().results.into_iter().map(Email::from).collect::<Vec<_>>()
+                }
+                Err(e) => {
+                    notify_error(format!("Failed to load emails: {e}"));
+                    Vec::new()
+                }
+            }
+        }
     });
 
-    let unreviewed_count = use_memo(move || {
-        EMAILS.read().iter().filter(|e| e.trip_id.is_none()).count()
-    });
+    let emails = email_resource.value();
+    let emails_read = emails.read();
+    let loading = emails_read.is_none();
+    let empty = Vec::new();
+    let email_list = emails_read.as_deref().unwrap_or(&empty);
+
+    let unreviewed_count = email_list.iter().filter(|e| e.trip_id.is_none()).count();
+
+    let filtered: Vec<_> = email_list
+        .iter()
+        .filter(|e| match active_filter().as_str() {
+            "Flights ✈️" => e.category == Category::Flight,
+            "Hotels 🏨" => e.category == Category::Hotel,
+            "Car Rental 🚗" => e.category == Category::CarRental,
+            "Cruises 🚢" => e.category == Category::Cruise,
+            "Other" => e.category == Category::Other || e.category == Category::Activity,
+            _ => true,
+        })
+        .cloned()
+        .collect();
 
     rsx! {
         div { class: "flex flex-col h-full bg-background",
@@ -58,7 +79,7 @@ pub fn EmailList() -> Element {
                 on_change: move |v: String| search.set(v),
             }
 
-            DiscoveryBanner { count: unreviewed_count() }
+            DiscoveryBanner { count: unreviewed_count }
 
             FilterChips {
                 active: active_filter(),
@@ -67,20 +88,25 @@ pub fn EmailList() -> Element {
 
             // Email list
             div { class: "flex-1 overflow-y-auto py-2 pb-4",
-                for email in filtered().iter() {
-                    EmailListItem {
-                        key: "{email.id}",
-                        email: email.clone(),
-                        on_click: move |id: String| {
-                            *SELECTED_EMAIL.write() = Some(id);
-                        },
+                if loading {
+                    div { class: "flex flex-col items-center justify-center py-12 text-muted",
+                        div { class: "w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin mb-3" }
+                        span { class: "text-sm", "Loading emails..." }
                     }
-                }
-
-                if filtered().is_empty() {
+                } else if filtered.is_empty() {
                     div { class: "flex flex-col items-center justify-center py-12 text-muted",
                         span { class: "text-4xl mb-2", "📭" }
                         span { class: "text-sm", "No emails match your search" }
+                    }
+                } else {
+                    for email in filtered.iter() {
+                        EmailListItem {
+                            key: "{email.id}",
+                            email: email.clone(),
+                            on_click: move |id: String| {
+                                *SELECTED_EMAIL.write() = Some(id);
+                            },
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Wires the EmailList view to the real backend API using the progenitor-generated client from #27.

## Changes
- `types.rs`: Add `From<NotmuchEmailResult> for Email` — maps backend fields to UI types, parses `from` field into sender/sender_email, maps snake_case category strings
- `email_list.rs`: Replace static `EMAILS` signal with `use_resource` calling `search_emails` API
- Loading spinner, error toast, client-side category filtering

## Depends on
- #27 (progenitor client)

## Test plan
- Emails load from API on mount (requires backend running)
- Category filter chips work
- Loading spinner shows during fetch
- Error toast when API unreachable
- Empty state when no results

Closes #16