### PR TITLE
feat(search): add advanced notmuch query help

### DIFF
--- a/src/components/search_bar.rs
+++ b/src/components/search_bar.rs
@@ -4,6 +4,8 @@ use dioxus_free_icons::Icon;
 
 #[component]
 pub fn SearchBar(value: String, on_change: EventHandler<String>) -> Element {
+    let mut show_advanced_help = use_signal(|| false);
+
     rsx! {
         div { class: "px-4 pt-3 pb-2",
             div { class: "flex items-center gap-2 bg-card rounded-xl px-3 py-2.5 border border-border",
@@ -13,6 +15,32 @@ pub fn SearchBar(value: String, on_change: EventHandler<String>) -> Element {
                     placeholder: "Search travel emails...",
                     value: "{value}",
                     oninput: move |e| on_change.call(e.value()),
+                }
+            }
+
+            div { class: "mt-2 px-1",
+                button {
+                    class: "text-xs text-muted underline underline-offset-2",
+                    r#type: "button",
+                    onclick: move |_| show_advanced_help.set(!show_advanced_help()),
+                    if show_advanced_help() {
+                        "Hide advanced search tips"
+                    } else {
+                        "Advanced search tips"
+                    }
+                }
+            }
+
+            if show_advanced_help() {
+                div { class: "mt-2 rounded-lg border border-border bg-card px-3 py-2 text-xs text-muted",
+                    p { class: "font-medium text-foreground mb-1", "Notmuch query examples" }
+                    ul { class: "space-y-0.5 list-disc pl-4",
+                        li { "from:delta" }
+                        li { "subject:\"flight\"" }
+                        li { "tag:unread" }
+                        li { "date:2026-04-01..2026-04-30" }
+                        li { "from:delta AND subject:itinerary" }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a discoverable "Advanced search tips" helper directly below the search field
- provide concise notmuch query examples in a collapsible, mobile-friendly help panel
- keep default/basic search flow unchanged unless users opt in to view tips

## Testing
- cargo check

Fixes #47