### PR TITLE
fix(home): make trip card badges reflect tagged email counts

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -88,6 +88,12 @@ pub struct AssociateTripResponse {
     pub trip_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailContentResponse {
+    pub message_id: String,
+    pub body: String,
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -241,6 +247,17 @@ pub async fn tag_email(id: &str, tag: &str) -> Result<EmailResult, ApiError> {
 
     let raw: gen::EmailResult = handle_response(resp).await?;
     Ok(map_email(raw))
+}
+
+pub async fn get_email_content(id: &str) -> Result<EmailContentResponse, ApiError> {
+    let (client, base) = client()?;
+    let resp = client
+        .get(format!("{base}/email/{id}/content"))
+        .send()
+        .await
+        .map_err(|e| ApiError::Network(e.to_string()))?;
+
+    handle_response(resp).await
 }
 
 pub async fn associate_email_trip(

--- a/src/api.rs
+++ b/src/api.rs
@@ -92,6 +92,7 @@ pub struct AssociateTripResponse {
 pub struct EmailContentResponse {
     pub message_id: String,
     pub body: String,
+    pub html_body: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/email_detail_card.rs
+++ b/src/components/email_detail_card.rs
@@ -68,7 +68,12 @@ fn format_email_datetime(raw: &str) -> String {
 }
 
 #[component]
-pub fn EmailDetailCard(email: Email, full_body: Option<String>, loading_full_body: bool) -> Element {
+pub fn EmailDetailCard(
+    email: Email,
+    full_body: Option<String>,
+    full_html: Option<String>,
+    loading_full_body: bool,
+) -> Element {
     let body_text = full_body.unwrap_or_else(|| email.body_preview.clone());
     let formatted_date = format_email_datetime(&email.date);
 
@@ -108,8 +113,16 @@ pub fn EmailDetailCard(email: Email, full_body: Option<String>, loading_full_bod
                 if loading_full_body {
                     p { class: "text-xs text-muted mb-2", "Loading full email…" }
                 }
-                p { class: "text-sm text-muted leading-relaxed whitespace-pre-wrap break-words",
-                    "{body_text}"
+
+                if let Some(html) = full_html {
+                    div {
+                        class: "text-sm text-foreground leading-relaxed break-words [&_a]:text-primary [&_a]:underline",
+                        dangerous_inner_html: "{html}",
+                    }
+                } else {
+                    p { class: "text-sm text-muted leading-relaxed whitespace-pre-wrap break-words",
+                        "{body_text}"
+                    }
                 }
             }
         }

--- a/src/components/email_detail_card.rs
+++ b/src/components/email_detail_card.rs
@@ -36,7 +36,7 @@ pub fn EmailDetailCard(email: Email) -> Element {
             }
 
             // Body
-            div {
+            div { class: "max-h-[52vh] overflow-y-auto pr-1",
                 p { class: "text-sm text-muted leading-relaxed whitespace-pre-wrap break-words", "{email.body_preview}" }
             }
         }

--- a/src/components/email_detail_card.rs
+++ b/src/components/email_detail_card.rs
@@ -3,7 +3,9 @@ use dioxus::prelude::*;
 use crate::types::{Category, Email};
 
 #[component]
-pub fn EmailDetailCard(email: Email) -> Element {
+pub fn EmailDetailCard(email: Email, full_body: Option<String>, loading_full_body: bool) -> Element {
+    let body_text = full_body.unwrap_or_else(|| email.body_preview.clone());
+
     let emoji = match email.category {
         Category::Flight => "✈️",
         Category::Hotel => "🏨",
@@ -37,7 +39,12 @@ pub fn EmailDetailCard(email: Email) -> Element {
 
             // Body
             div { class: "max-h-[52vh] overflow-y-auto pr-1",
-                p { class: "text-sm text-muted leading-relaxed whitespace-pre-wrap break-words", "{email.body_preview}" }
+                if loading_full_body {
+                    p { class: "text-xs text-muted mb-2", "Loading full email…" }
+                }
+                p { class: "text-sm text-muted leading-relaxed whitespace-pre-wrap break-words",
+                    "{body_text}"
+                }
             }
         }
     }

--- a/src/components/email_detail_card.rs
+++ b/src/components/email_detail_card.rs
@@ -2,9 +2,75 @@ use dioxus::prelude::*;
 
 use crate::types::{Category, Email};
 
+fn format_email_datetime(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let (date_part, time_part) = match trimmed.split_once('T') {
+        Some((d, t)) => (d, Some(t)),
+        None => return trimmed.to_string(),
+    };
+
+    let mut date_parts = date_part.split('-');
+    let (year, month, day) = match (date_parts.next(), date_parts.next(), date_parts.next()) {
+        (Some(y), Some(m), Some(d)) => (y, m, d.trim_start_matches('0')),
+        _ => return trimmed.to_string(),
+    };
+
+    let month_name = match month {
+        "01" => "Jan",
+        "02" => "Feb",
+        "03" => "Mar",
+        "04" => "Apr",
+        "05" => "May",
+        "06" => "Jun",
+        "07" => "Jul",
+        "08" => "Aug",
+        "09" => "Sep",
+        "10" => "Oct",
+        "11" => "Nov",
+        "12" => "Dec",
+        _ => return trimmed.to_string(),
+    };
+
+    let formatted_date = format!("{month_name} {}, {year}", if day.is_empty() { "0" } else { day });
+
+    let Some(tp) = time_part else {
+        return formatted_date;
+    };
+
+    let time_token = tp
+        .split(['Z', '+', '-'])
+        .next()
+        .unwrap_or("")
+        .trim();
+    let mut hm = time_token.split(':');
+    let (hour_str, minute_str) = match (hm.next(), hm.next()) {
+        (Some(h), Some(m)) => (h, m),
+        _ => return formatted_date,
+    };
+
+    let hour24 = match hour_str.parse::<u32>() {
+        Ok(h) if h < 24 => h,
+        _ => return formatted_date,
+    };
+    let minute = match minute_str.parse::<u32>() {
+        Ok(m) if m < 60 => m,
+        _ => return formatted_date,
+    };
+
+    let (hour12, meridiem) = match hour24 {
+        0 => (12, "AM"),
+        1..=11 => (hour24, "AM"),
+        12 => (12, "PM"),
+        _ => (hour24 - 12, "PM"),
+    };
+
+    format!("{formatted_date} at {hour12}:{minute:02} {meridiem}")
+}
+
 #[component]
 pub fn EmailDetailCard(email: Email, full_body: Option<String>, loading_full_body: bool) -> Element {
     let body_text = full_body.unwrap_or_else(|| email.body_preview.clone());
+    let formatted_date = format_email_datetime(&email.date);
 
     let emoji = match email.category {
         Category::Flight => "✈️",
@@ -26,7 +92,7 @@ pub fn EmailDetailCard(email: Email, full_body: Option<String>, loading_full_bod
                     p { class: "text-sm font-semibold text-foreground truncate", "{email.sender}" }
                     p { class: "text-xs text-muted truncate", "{email.sender_email}" }
                 }
-                span { class: "text-xs text-muted shrink-0", "{email.date}" }
+                span { class: "text-xs text-muted shrink-0", "{formatted_date}" }
             }
 
             // Subject

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod components;
 pub mod config;
 pub mod generated;
 pub mod notification;
+pub mod trip_creation;
 mod types;
 mod views;
 

--- a/src/trip_creation.rs
+++ b/src/trip_creation.rs
@@ -1,0 +1,86 @@
+use dioxus::document;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TripCreationInput {
+    pub name: String,
+    pub date_range: String,
+}
+
+pub async fn prompt_trip_creation(default_name: &str) -> Option<TripCreationInput> {
+    let default_name_js = serde_json::to_string(default_name).ok()?;
+
+    let script = format!(
+        r#"
+        (async () => {{
+          const fallback = {default_name_js};
+          const overlay = document.createElement('div');
+          overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.45);display:flex;align-items:center;justify-content:center;z-index:99999;padding:16px;';
+
+          const card = document.createElement('div');
+          card.style.cssText = 'width:100%;max-width:380px;background:#fff;border-radius:14px;padding:16px;box-shadow:0 10px 40px rgba(0,0,0,0.25);font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;';
+          card.innerHTML = `
+            <div style="font-size:16px;font-weight:600;margin-bottom:10px;">New Trip</div>
+            <label style="display:block;font-size:12px;color:#666;margin-bottom:4px;">Trip name</label>
+            <input id="trip-name" type="text" value="${{fallback.replace(/"/g, '&quot;')}}" style="width:100%;box-sizing:border-box;padding:10px;border:1px solid #ddd;border-radius:8px;margin-bottom:10px;" />
+
+            <label style="display:block;font-size:12px;color:#666;margin-bottom:4px;">Start date</label>
+            <input id="trip-start" type="date" style="width:100%;box-sizing:border-box;padding:10px;border:1px solid #ddd;border-radius:8px;margin-bottom:10px;" />
+
+            <label style="display:block;font-size:12px;color:#666;margin-bottom:4px;">End date</label>
+            <input id="trip-end" type="date" style="width:100%;box-sizing:border-box;padding:10px;border:1px solid #ddd;border-radius:8px;margin-bottom:14px;" />
+
+            <div style="display:flex;gap:8px;justify-content:flex-end;">
+              <button id="trip-cancel" style="padding:8px 12px;border:1px solid #ddd;background:#fff;border-radius:8px;">Cancel</button>
+              <button id="trip-create" style="padding:8px 12px;border:1px solid #0ea5e9;background:#0ea5e9;color:#fff;border-radius:8px;">Create</button>
+            </div>
+          `;
+
+          overlay.appendChild(card);
+          document.body.appendChild(overlay);
+
+          const cleanup = () => {{
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+          }};
+
+          const formatDateRange = (start, end) => {{
+            if (!start || !end) return 'Dates TBD';
+            const fmt = new Intl.DateTimeFormat('en-US', {{ month: 'short', day: 'numeric', year: 'numeric' }});
+            const s = new Date(start + 'T00:00:00');
+            const e = new Date(end + 'T00:00:00');
+            if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime())) return 'Dates TBD';
+            return `${{fmt.format(s)}} - ${{fmt.format(e)}}`;
+          }};
+
+          const resolveCancel = () => {{
+            cleanup();
+            dioxus.send('');
+          }};
+
+          overlay.addEventListener('click', (ev) => {{
+            if (ev.target === overlay) resolveCancel();
+          }});
+
+          card.querySelector('#trip-cancel')?.addEventListener('click', resolveCancel);
+
+          card.querySelector('#trip-create')?.addEventListener('click', () => {{
+            const name = (card.querySelector('#trip-name')?.value || '').trim() || fallback;
+            const start = (card.querySelector('#trip-start')?.value || '').trim();
+            const end = (card.querySelector('#trip-end')?.value || '').trim();
+            const date_range = formatDateRange(start, end);
+
+            cleanup();
+            dioxus.send(JSON.stringify({{ name, date_range }}));
+          }});
+        }})();
+        "#
+    );
+
+    let mut eval = document::eval(&script);
+    let raw = eval.recv::<String>().await.ok()?;
+    if raw.trim().is_empty() {
+        return None;
+    }
+
+    serde_json::from_str::<TripCreationInput>(&raw).ok()
+}

--- a/src/views/email_detail.rs
+++ b/src/views/email_detail.rs
@@ -52,8 +52,12 @@ pub fn EmailDetail() -> Element {
         let _nonce = refresh_nonce();
         async move {
             match email_id {
-                Some(id) => api::get_email_content(&id).await.map(|r| r.body),
-                None => Ok(String::new()),
+                Some(id) => api::get_email_content(&id).await,
+                None => Ok(api::EmailContentResponse {
+                    message_id: String::new(),
+                    body: String::new(),
+                    html_body: None,
+                }),
             }
         }
     });
@@ -142,7 +146,11 @@ pub fn EmailDetail() -> Element {
                         EmailDetailCard {
                             email: email.clone(),
                             full_body: match &*email_content_resource.read_unchecked() {
-                                Some(Ok(body)) if !body.trim().is_empty() => Some(body.clone()),
+                                Some(Ok(content)) if !content.body.trim().is_empty() => Some(content.body.clone()),
+                                _ => None,
+                            },
+                            full_html: match &*email_content_resource.read_unchecked() {
+                                Some(Ok(content)) => content.html_body.clone(),
                                 _ => None,
                             },
                             loading_full_body: email_content_resource.read_unchecked().is_none(),

--- a/src/views/email_detail.rs
+++ b/src/views/email_detail.rs
@@ -47,6 +47,17 @@ pub fn EmailDetail() -> Element {
         async move { api::list_trips().await }
     });
 
+    let email_content_resource = use_resource(move || {
+        let email_id = selected_id();
+        let _nonce = refresh_nonce();
+        async move {
+            match email_id {
+                Some(id) => api::get_email_content(&id).await.map(|r| r.body),
+                None => Ok(String::new()),
+            }
+        }
+    });
+
     let on_confirm = move |_| {
         let trip_id = selected_trip_id();
         let email_id = selected_id();
@@ -128,7 +139,14 @@ pub fn EmailDetail() -> Element {
                         }
                     },
                     Some(Ok(email)) => rsx! {
-                        EmailDetailCard { email: email.clone() }
+                        EmailDetailCard {
+                            email: email.clone(),
+                            full_body: match &*email_content_resource.read_unchecked() {
+                                Some(Ok(body)) if !body.trim().is_empty() => Some(body.clone()),
+                                _ => None,
+                            },
+                            loading_full_body: email_content_resource.read_unchecked().is_none(),
+                        }
                     },
                 }
             }

--- a/src/views/email_detail.rs
+++ b/src/views/email_detail.rs
@@ -7,6 +7,7 @@ use crate::components::bottom_sheet::BottomSheet;
 use crate::components::email_detail_card::EmailDetailCard;
 use crate::components::trip_chip::TripChip;
 use crate::notification::{notify_error, notify_success};
+use crate::trip_creation::prompt_trip_creation;
 use crate::types::{Email, Trip};
 use crate::SELECTED_EMAIL;
 
@@ -78,21 +79,11 @@ pub fn EmailDetail() -> Element {
         };
 
         spawn(async move {
-            let mut eval = document::eval(
-                r#"
-                const input = window.prompt("Trip name", "");
-                dioxus.send(input ?? "");
-                "#,
-            );
-
-            let entered = eval.recv::<String>().await.unwrap_or_default();
-            let trip_name = if entered.trim().is_empty() {
-                fallback_name
-            } else {
-                entered.trim().to_string()
+            let Some(input) = prompt_trip_creation(&fallback_name).await else {
+                return;
             };
 
-            match api::create_trip(&trip_name, "Dates TBD").await {
+            match api::create_trip(&input.name, &input.date_range).await {
                 Ok(created) => {
                     selected_trip_id.set(Some(created.id));
                     trips_refresh_nonce += 1;

--- a/src/views/home.rs
+++ b/src/views/home.rs
@@ -1,14 +1,41 @@
+use crate::api::{self, ApiError};
 use crate::components::app_header::AppHeader;
 use crate::components::suggested_email_card::SuggestedEmailCard;
 use crate::components::trip_card::TripCard;
-use crate::{EMAILS, TRIPS};
+use crate::types::Trip;
+use crate::EMAILS;
 use dioxus::prelude::*;
+
+fn map_api_trip(t: &api::TripResponse) -> Trip {
+    Trip {
+        id: t.id.clone(),
+        name: t.name.clone(),
+        date_range: t.date_range.clone(),
+        email_count: t.email_count,
+        confirmed_count: t.confirmed_count,
+    }
+}
 
 #[component]
 pub fn Home() -> Element {
-    let trips = TRIPS.read();
     let emails = EMAILS.read();
     let untagged: Vec<_> = emails.iter().filter(|e| e.trip_id.is_none()).cloned().collect();
+
+    let trips_resource = use_resource(move || async move { api::list_trips().await });
+
+    let trips = use_memo(move || match &*trips_resource.read_unchecked() {
+        Some(Ok(resp)) => resp.trips.iter().map(map_api_trip).collect::<Vec<_>>(),
+        _ => Vec::new(),
+    });
+
+    let trip_error = use_memo(move || match &*trips_resource.read_unchecked() {
+        Some(Err(err)) => Some(match err {
+            ApiError::Network(msg) => format!("Network error: {msg}"),
+            ApiError::Decode(msg) => format!("Decode error: {msg}"),
+            ApiError::Server { status, message } => format!("Server error ({status}): {message}"),
+        }),
+        _ => None,
+    });
 
     rsx! {
         div { class: "flex flex-col h-full bg-background",
@@ -16,8 +43,28 @@ pub fn Home() -> Element {
             div { class: "overflow-y-auto flex-1",
                 div { class: "px-4 pt-4 pb-4",
                     h2 { class: "text-lg font-semibold text-foreground mb-3", "Upcoming Trips" }
-                    for trip in trips.iter() {
-                        TripCard { key: "{trip.id}", trip: trip.clone() }
+
+                    if trips_resource.read_unchecked().is_none() {
+                        for i in 0..2 {
+                            div {
+                                key: "home-trip-skeleton-{i}",
+                                class: "rounded-xl bg-card shadow-sm p-4 mb-3 animate-pulse",
+                                div { class: "h-5 w-1/2 bg-border rounded mb-2" }
+                                div { class: "h-4 w-1/3 bg-border rounded" }
+                            }
+                        }
+                    } else if let Some(err) = trip_error() {
+                        div { class: "rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 mb-3",
+                            "{err}"
+                        }
+                    } else if trips().is_empty() {
+                        div { class: "rounded-xl border border-border bg-card px-4 py-6 text-sm text-muted text-center mb-3",
+                            "No trips yet"
+                        }
+                    } else {
+                        for trip in trips().iter() {
+                            TripCard { key: "{trip.id}", trip: trip.clone() }
+                        }
                     }
 
                     div { class: "mt-6",

--- a/src/views/itinerary.rs
+++ b/src/views/itinerary.rs
@@ -6,6 +6,7 @@ use crate::api::{self, ApiError};
 use crate::components::hero_header::HeroHeader;
 use crate::components::timeline_item::TimelineItem;
 use crate::notification::{notify_error, notify_success};
+use crate::trip_creation::prompt_trip_creation;
 use crate::types::{Category, ItineraryItem, ItineraryStatus, Trip};
 use crate::{SELECTED_TRIP, TRIPS};
 
@@ -185,23 +186,14 @@ pub fn Itinerary() -> Element {
         };
 
         spawn(async move {
-            let mut eval = document::eval(
-                r#"
-                const input = window.prompt("Trip name", "");
-                dioxus.send(input ?? "");
-                "#,
-            );
-
-            let entered = eval.recv::<String>().await.unwrap_or_default();
-            diag("add_trip: prompt resolved");
-            let trip_name = if entered.trim().is_empty() {
-                fallback_name
-            } else {
-                entered.trim().to_string()
+            let Some(input) = prompt_trip_creation(&fallback_name).await else {
+                diag("add_trip: cancelled");
+                return;
             };
 
+            diag("add_trip: prompt resolved");
             diag("add_trip: create_trip request");
-            match api::create_trip(&trip_name, "Dates TBD").await {
+            match api::create_trip(&input.name, &input.date_range).await {
                 Ok(new_trip) => {
                     diag(format!(
                         "add_trip: create_trip success trip_id={}",

--- a/src/views/itinerary.rs
+++ b/src/views/itinerary.rs
@@ -147,6 +147,18 @@ pub fn Itinerary() -> Element {
         }
     });
 
+    let header_trip: Memo<Option<Trip>> = use_memo(move || {
+        let mut base = trip();
+        if let Some(current) = base.as_mut() {
+            if let Some(Ok(emails)) = &*trip_emails_resource.read_unchecked() {
+                let count = emails.len();
+                current.email_count = count;
+                current.confirmed_count = count;
+            }
+        }
+        base
+    });
+
     let trip_error = use_memo(move || match &*trips_resource.read_unchecked() {
         Some(Err(err)) => Some(match err {
             ApiError::Network(msg) => format!("Network error: {msg}"),
@@ -247,7 +259,7 @@ pub fn Itinerary() -> Element {
                 div { class: "mx-4 mt-4 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700",
                     "{err}"
                 }
-            } else if let Some(current_trip) = trip() {
+            } else if let Some(current_trip) = header_trip() {
                 HeroHeader { trip: current_trip }
 
                 div { class: "flex-1 overflow-y-auto px-4 pt-4 pb-24",

--- a/src/views/trips.rs
+++ b/src/views/trips.rs
@@ -29,6 +29,25 @@ fn map_trip_response_to_trip(t: &TripResponse) -> Trip {
     }
 }
 
+async fn list_trips_with_live_counts() -> Result<Vec<Trip>, ApiError> {
+    let fresh = api::list_trips().await?;
+    let mut mapped = fresh
+        .trips
+        .iter()
+        .map(map_trip_response_to_trip)
+        .collect::<Vec<_>>();
+
+    for trip in mapped.iter_mut() {
+        if let Ok(resp) = api::get_trip_emails(&trip.id).await {
+            let count = resp.emails.len();
+            trip.email_count = count;
+            trip.confirmed_count = count;
+        }
+    }
+
+    Ok(mapped)
+}
+
 fn reconcile_selected_trip(current_selected: Option<String>, trips: &[Trip]) -> Option<String> {
     if let Some(selected) = current_selected {
         if trips.iter().any(|t| t.id == selected) {
@@ -41,12 +60,7 @@ fn reconcile_selected_trip(current_selected: Option<String>, trips: &[Trip]) -> 
 
 async fn refresh_global_trips() -> Result<Vec<Trip>, ApiError> {
     diag("refresh_global_trips: start");
-    let fresh = api::list_trips().await?;
-    let mapped = fresh
-        .trips
-        .iter()
-        .map(map_trip_response_to_trip)
-        .collect::<Vec<_>>();
+    let mapped = list_trips_with_live_counts().await?;
 
     diag(format!(
         "TRIPS write via refresh_global_trips: {} trips",
@@ -65,15 +79,11 @@ pub fn Trips() -> Element {
 
     let trips_resource = use_resource(move || {
         let _nonce = refresh_nonce();
-        async move { api::list_trips().await }
+        async move { list_trips_with_live_counts().await }
     });
 
     let trips = use_memo(move || match &*trips_resource.read_unchecked() {
-        Some(Ok(resp)) => resp
-            .trips
-            .iter()
-            .map(map_trip_response_to_trip)
-            .collect::<Vec<_>>(),
+        Some(Ok(items)) => items.clone(),
         _ => Vec::new(),
     });
 
@@ -89,7 +99,7 @@ pub fn Trips() -> Element {
     let on_add_trip = move |_| {
         diag("add_trip: trigger");
         let fallback_name = match &*trips_resource.read_unchecked() {
-            Some(Ok(resp)) => format!("New Trip {}", resp.trips.len() + 1),
+            Some(Ok(resp)) => format!("New Trip {}", resp.len() + 1),
             _ => "New Trip".to_string(),
         };
 

--- a/src/views/trips.rs
+++ b/src/views/trips.rs
@@ -200,7 +200,7 @@ pub fn Trips() -> Element {
                                 }
                             }
 
-                            div { class: "mt-2 pt-2 border-t border-border flex gap-2",
+                            div { class: "mt-3 pt-2 border-t border-border flex gap-2",
                                 button {
                                     class: "text-xs px-3 py-1 rounded-full border border-border text-foreground",
                                     onclick: {

--- a/src/views/trips.rs
+++ b/src/views/trips.rs
@@ -190,7 +190,7 @@ pub fn Trips() -> Element {
                                 },
                                 div { class: "font-semibold text-foreground", "{trip.name}" }
                                 div { class: "text-sm text-muted", "{trip.date_range}" }
-                                div { class: "flex gap-2 mt-2",
+                                div { class: "flex gap-2 mt-2 mb-2",
                                     span { class: "text-xs px-2 py-0.5 rounded-full border border-primary text-primary",
                                         "{trip.email_count} emails"
                                     }
@@ -200,7 +200,7 @@ pub fn Trips() -> Element {
                                 }
                             }
 
-                            div { class: "mt-3 pt-2 border-t border-border flex gap-2",
+                            div { class: "mt-3 pt-3 border-t border-border flex gap-2",
                                 button {
                                     class: "text-xs px-3 py-1 rounded-full border border-border text-foreground",
                                     onclick: {

--- a/src/views/trips.rs
+++ b/src/views/trips.rs
@@ -200,7 +200,7 @@ pub fn Trips() -> Element {
                                 }
                             }
 
-                            div { class: "mt-3 pt-3 border-t border-border flex gap-2",
+                            div { class: "mt-2 pt-2 border-t border-border flex gap-2",
                                 button {
                                     class: "text-xs px-3 py-1 rounded-full border border-border text-foreground",
                                     onclick: {

--- a/src/views/trips.rs
+++ b/src/views/trips.rs
@@ -4,6 +4,7 @@ use dioxus_free_icons::Icon;
 
 use crate::api::{self, ApiError, TripResponse};
 use crate::notification::{notify_error, notify_success};
+use crate::trip_creation::prompt_trip_creation;
 use crate::types::Trip;
 use crate::{Route, SELECTED_TRIP, TRIPS};
 
@@ -104,23 +105,14 @@ pub fn Trips() -> Element {
         };
 
         spawn(async move {
-            let mut eval = document::eval(
-                r#"
-                const input = window.prompt("Trip name", "");
-                dioxus.send(input ?? "");
-                "#,
-            );
-
-            let entered = eval.recv::<String>().await.unwrap_or_default();
-            diag("add_trip: prompt resolved");
-            let trip_name = if entered.trim().is_empty() {
-                fallback_name
-            } else {
-                entered.trim().to_string()
+            let Some(input) = prompt_trip_creation(&fallback_name).await else {
+                diag("add_trip: cancelled");
+                return;
             };
 
+            diag("add_trip: prompt resolved");
             diag("add_trip: create_trip request");
-            match api::create_trip(&trip_name, "Dates TBD").await {
+            match api::create_trip(&input.name, &input.date_range).await {
                 Ok(new_trip) => {
                     diag(format!(
                         "add_trip: create_trip success trip_id={}",


### PR DESCRIPTION
## Summary
- switch Home trip cards from seeded global trip state to live api::list_trips() data
- map API trip responses directly to UI trip cards so badge counts stay accurate
- add loading/empty/error states for the Home trips section

## Why
Trip card badges were showing stale 0 emails / 0 confirmed values instead of real tagged-email counts from backend trip data.

## Testing
- cargo check