### PR TITLE
feat: classifier settings UI with save/reset flows (#54)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -104,6 +104,7 @@ pub struct CategoryRule {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClassifiersConfig {
     pub categories: std::collections::HashMap<String, CategoryRule>,
+    pub category_titles: std::collections::HashMap<String, String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +224,10 @@ fn map_classifiers(raw: gen::ClassifierClassifiersConfig) -> ClassifiersConfig {
         })
         .collect();
 
-    ClassifiersConfig { categories }
+    ClassifiersConfig {
+        categories,
+        category_titles: raw.category_titles.unwrap_or_default(),
+    }
 }
 
 fn unmap_classifiers(cfg: &ClassifiersConfig) -> gen::ClassifierClassifiersConfig {
@@ -243,6 +247,7 @@ fn unmap_classifiers(cfg: &ClassifiersConfig) -> gen::ClassifierClassifiersConfi
 
     gen::ClassifierClassifiersConfig {
         categories: Some(categories),
+        category_titles: Some(cfg.category_titles.clone()),
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -95,6 +95,17 @@ pub struct EmailContentResponse {
     pub html_body: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CategoryRule {
+    pub domains: Vec<String>,
+    pub subject_keywords: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifiersConfig {
+    pub categories: std::collections::HashMap<String, CategoryRule>,
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -126,7 +137,8 @@ fn client() -> Result<(reqwest::Client, String), ApiError> {
     if cfg.server_url.trim().is_empty() {
         return Err(ApiError::Server {
             status: 400,
-            message: "Server is not configured yet. Open Settings and connect your server.".to_string(),
+            message: "Server is not configured yet. Open Settings and connect your server."
+                .to_string(),
         });
     }
 
@@ -195,6 +207,45 @@ fn map_trip(raw: gen::TripResponse) -> TripResponse {
     }
 }
 
+fn map_classifiers(raw: gen::ClassifierClassifiersConfig) -> ClassifiersConfig {
+    let categories = raw
+        .categories
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(name, rule)| {
+            (
+                name,
+                CategoryRule {
+                    domains: rule.domains.unwrap_or_default(),
+                    subject_keywords: rule.subject_keywords.unwrap_or_default(),
+                },
+            )
+        })
+        .collect();
+
+    ClassifiersConfig { categories }
+}
+
+fn unmap_classifiers(cfg: &ClassifiersConfig) -> gen::ClassifierClassifiersConfig {
+    let categories = cfg
+        .categories
+        .iter()
+        .map(|(name, rule)| {
+            (
+                name.clone(),
+                gen::ClassifierCategoryRule {
+                    domains: Some(rule.domains.clone()),
+                    subject_keywords: Some(rule.subject_keywords.clone()),
+                },
+            )
+        })
+        .collect();
+
+    gen::ClassifierClassifiersConfig {
+        categories: Some(categories),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public API functions
 // ---------------------------------------------------------------------------
@@ -259,6 +310,43 @@ pub async fn get_email_content(id: &str) -> Result<EmailContentResponse, ApiErro
         .map_err(|e| ApiError::Network(e.to_string()))?;
 
     handle_response(resp).await
+}
+
+pub async fn get_classifiers() -> Result<ClassifiersConfig, ApiError> {
+    let (client, base) = client()?;
+    let resp = client
+        .get(format!("{base}/classifiers"))
+        .send()
+        .await
+        .map_err(|e| ApiError::Network(e.to_string()))?;
+
+    let raw: gen::ClassifierClassifiersConfig = handle_response(resp).await?;
+    Ok(map_classifiers(raw))
+}
+
+pub async fn update_classifiers(config: &ClassifiersConfig) -> Result<ClassifiersConfig, ApiError> {
+    let (client, base) = client()?;
+    let resp = client
+        .put(format!("{base}/classifiers"))
+        .json(&unmap_classifiers(config))
+        .send()
+        .await
+        .map_err(|e| ApiError::Network(e.to_string()))?;
+
+    let raw: gen::ClassifierClassifiersConfig = handle_response(resp).await?;
+    Ok(map_classifiers(raw))
+}
+
+pub async fn reset_classifiers() -> Result<ClassifiersConfig, ApiError> {
+    let (client, base) = client()?;
+    let resp = client
+        .post(format!("{base}/classifiers/reset"))
+        .send()
+        .await
+        .map_err(|e| ApiError::Network(e.to_string()))?;
+
+    let raw: gen::ClassifierClassifiersConfig = handle_response(resp).await?;
+    Ok(map_classifiers(raw))
 }
 
 pub async fn associate_email_trip(

--- a/src/components/filter_chips.rs
+++ b/src/components/filter_chips.rs
@@ -1,26 +1,35 @@
 use dioxus::prelude::*;
 
-const FILTERS: &[&str] = &["All", "Flights ✈️", "Hotels 🏨", "Car Rental 🚗", "Cruises 🚢", "Other"];
+#[derive(Clone, PartialEq)]
+pub struct FilterChip {
+    pub key: String,
+    pub label: String,
+}
 
 #[component]
-pub fn FilterChips(active: String, on_change: EventHandler<String>) -> Element {
+pub fn FilterChips(
+    active: String,
+    filters: Vec<FilterChip>,
+    on_change: EventHandler<String>,
+) -> Element {
     rsx! {
         div { class: "flex gap-2 px-4 overflow-x-auto pb-2 scrollbar-hide",
-            for filter in FILTERS.iter() {
+            for filter in filters.into_iter() {
                 {
-                    let is_active = active == *filter;
+                    let is_active = active == filter.key;
                     let class = if is_active {
                         "bg-primary text-white rounded-full px-3 py-1 text-sm whitespace-nowrap cursor-pointer"
                     } else {
                         "border border-border text-muted rounded-full px-3 py-1 text-sm bg-card whitespace-nowrap cursor-pointer"
                     };
-                    let label = filter.to_string();
-                    let label2 = label.clone();
+                    let key = filter.key.clone();
+                    let label = filter.label.clone();
                     rsx! {
                         button {
+                            key: "{key}",
                             class: "{class}",
-                            onclick: move |_| on_change.call(label.clone()),
-                            "{label2}"
+                            onclick: move |_| on_change.call(key.clone()),
+                            "{label}"
                         }
                     }
                 }

--- a/src/generated/api_types.rs
+++ b/src/generated/api_types.rs
@@ -11,6 +11,7 @@ pub struct ClassifierCategoryRule {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClassifierClassifiersConfig {
     pub categories: Option<std::collections::HashMap<String, ClassifierCategoryRule>>,
+    pub category_titles: Option<std::collections::HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/generated/api_types.rs
+++ b/src/generated/api_types.rs
@@ -3,6 +3,17 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifierCategoryRule {
+    pub domains: Option<Vec<String>>,
+    pub subject_keywords: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifierClassifiersConfig {
+    pub categories: Option<std::collections::HashMap<String, ClassifierCategoryRule>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TripEmailItem {
     pub date: Option<String>,
     pub filename: Option<String>,
@@ -40,6 +51,13 @@ pub struct TripResponse {
     pub email_count: Option<i64>,
     pub id: Option<String>,
     pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotmuchEmailContentResponse {
+    pub body: Option<String>,
+    pub html_body: Option<String>,
+    pub message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ pub mod trip_creation;
 mod types;
 mod views;
 
+use api::ClassifiersConfig;
 use config::load_config;
 use types::*;
 
@@ -22,6 +23,7 @@ pub static SELECTED_TRIP: GlobalSignal<Option<String>> = Signal::global(|| None)
 pub static EMAIL_LIST_QUERY: GlobalSignal<String> = Signal::global(String::new);
 pub static EMAIL_LIST_FILTER: GlobalSignal<String> = Signal::global(|| "All".to_string());
 pub static ITINERARY: GlobalSignal<Vec<ItineraryItem>> = Signal::global(|| seed_itinerary());
+pub static CLASSIFIERS: GlobalSignal<Option<ClassifiersConfig>> = Signal::global(|| None);
 
 fn seed_emails() -> Vec<Email> {
     vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ pub static TRIPS: GlobalSignal<Vec<Trip>> = Signal::global(|| seed_trips());
 pub static SELECTED_EMAIL: GlobalSignal<Option<String>> = Signal::global(|| None);
 pub static SELECTED_TRIP: GlobalSignal<Option<String>> = Signal::global(|| None);
 pub static EMAIL_LIST_QUERY: GlobalSignal<String> = Signal::global(String::new);
-pub static EMAIL_LIST_FILTER: GlobalSignal<String> = Signal::global(|| "All".to_string());
+pub static EMAIL_LIST_FILTER: GlobalSignal<String> = Signal::global(|| "all".to_string());
 pub static ITINERARY: GlobalSignal<Vec<ItineraryItem>> = Signal::global(|| seed_itinerary());
 pub static CLASSIFIERS: GlobalSignal<Option<ClassifiersConfig>> = Signal::global(|| None);
 

--- a/src/views/email_list.rs
+++ b/src/views/email_list.rs
@@ -5,41 +5,123 @@ use dioxus_free_icons::Icon;
 use crate::api::{self, ApiError};
 use crate::components::discovery_banner::DiscoveryBanner;
 use crate::components::email_list_item::EmailListItem;
-use crate::components::filter_chips::FilterChips;
+use crate::components::filter_chips::{FilterChip, FilterChips};
 use crate::components::search_bar::SearchBar;
 use crate::types::{Category, Email};
 use crate::Route;
 use crate::{CLASSIFIERS, EMAIL_LIST_FILTER, EMAIL_LIST_QUERY, SELECTED_EMAIL};
 
-fn filter_matches(category: &Category, active_filter: &str) -> bool {
-    match active_filter {
-        "Flights ✈️" => *category == Category::Flight,
-        "Hotels 🏨" => *category == Category::Hotel,
-        "Car Rental 🚗" => *category == Category::CarRental,
-        "Cruises 🚢" => *category == Category::Cruise,
-        "Other" => *category == Category::Other || *category == Category::Activity,
-        _ => true, // "All"
+fn category_key(category: &Category) -> &'static str {
+    match category {
+        Category::Flight => "flight",
+        Category::Hotel => "hotel",
+        Category::CarRental => "car_rental",
+        Category::Cruise => "cruise",
+        Category::Activity => "activity",
+        Category::Other => "other",
     }
 }
 
-/// Map a filter-chip label to the classifier category key used by the backend.
-fn pill_to_classifier_key(pill: &str) -> Option<&'static str> {
-    match pill {
-        "Flights ✈️" => Some("flights"),
-        "Hotels 🏨" => Some("hotels"),
-        "Car Rental 🚗" => Some("car_rental"),
-        "Cruises 🚢" => Some("cruises"),
-        "Other" => Some("other"),
-        _ => None,
+fn filter_matches(category: &Category, active_filter: &str) -> bool {
+    active_filter == "all" || category_key(category) == active_filter
+}
+
+fn fallback_title_for_category(key: &str) -> String {
+    match key {
+        "flight" => "Flights ✈️".to_string(),
+        "hotel" => "Hotels 🏨".to_string(),
+        "car_rental" => "Car Rental 🚗".to_string(),
+        "cruise" => "Cruises 🚢".to_string(),
+        "activity" => "Activities 🎟️".to_string(),
+        "other" => "Other 📧".to_string(),
+        _ => key
+            .split('_')
+            .map(|w| {
+                let mut chars = w.chars();
+                match chars.next() {
+                    Some(first) => {
+                        first.to_uppercase().collect::<String>() + chars.as_str()
+                    }
+                    None => String::new(),
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" "),
     }
+}
+
+fn chip_filters() -> Vec<FilterChip> {
+    let mut out = vec![FilterChip {
+        key: "all".to_string(),
+        label: "All".to_string(),
+    }];
+
+    let cfg = CLASSIFIERS();
+    let Some(cfg) = cfg.as_ref() else {
+        out.push(FilterChip {
+            key: "flight".to_string(),
+            label: fallback_title_for_category("flight"),
+        });
+        out.push(FilterChip {
+            key: "hotel".to_string(),
+            label: fallback_title_for_category("hotel"),
+        });
+        out.push(FilterChip {
+            key: "car_rental".to_string(),
+            label: fallback_title_for_category("car_rental"),
+        });
+        out.push(FilterChip {
+            key: "cruise".to_string(),
+            label: fallback_title_for_category("cruise"),
+        });
+        out.push(FilterChip {
+            key: "activity".to_string(),
+            label: fallback_title_for_category("activity"),
+        });
+        return out;
+    };
+
+    let preferred_order = ["flight", "hotel", "car_rental", "cruise", "activity", "other"];
+    for key in preferred_order {
+        if cfg.categories.contains_key(key) {
+            out.push(FilterChip {
+                key: key.to_string(),
+                label: cfg
+                    .category_titles
+                    .get(key)
+                    .cloned()
+                    .unwrap_or_else(|| fallback_title_for_category(key)),
+            });
+        }
+    }
+
+    let mut extras = cfg
+        .categories
+        .keys()
+        .filter(|k| !preferred_order.contains(&k.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    extras.sort();
+
+    for key in extras {
+        out.push(FilterChip {
+            label: cfg
+                .category_titles
+                .get(&key)
+                .cloned()
+                .unwrap_or_else(|| fallback_title_for_category(&key)),
+            key,
+        });
+    }
+
+    out
 }
 
 /// Build a search query from a classifier category's subject keywords.
-fn query_from_classifier(filter: &str) -> Option<String> {
-    let key = pill_to_classifier_key(filter)?;
+fn query_from_classifier(category_key: &str) -> Option<String> {
     let classifiers = CLASSIFIERS();
     let cfg = classifiers.as_ref()?;
-    let rule = cfg.categories.get(key)?;
+    let rule = cfg.categories.get(category_key)?;
     if rule.subject_keywords.is_empty() {
         return None;
     }
@@ -136,8 +218,8 @@ pub fn EmailList() -> Element {
                 on_change: move |v: String| {
                     // When the user types, reset filter to All so the manual
                     // query drives search without category restriction.
-                    if EMAIL_LIST_FILTER() != "All" {
-                        *EMAIL_LIST_FILTER.write() = "All".to_string();
+                    if EMAIL_LIST_FILTER() != "all" {
+                        *EMAIL_LIST_FILTER.write() = "all".to_string();
                     }
                     *EMAIL_LIST_QUERY.write() = v;
                 },
@@ -147,9 +229,10 @@ pub fn EmailList() -> Element {
 
             FilterChips {
                 active: EMAIL_LIST_FILTER(),
+                filters: chip_filters(),
                 on_change: move |v: String| {
                     *EMAIL_LIST_FILTER.write() = v.clone();
-                    if v != "All" {
+                    if v != "all" {
                         if let Some(q) = query_from_classifier(&v) {
                             *EMAIL_LIST_QUERY.write() = q;
                         }

--- a/src/views/email_list.rs
+++ b/src/views/email_list.rs
@@ -63,7 +63,6 @@ fn to_ui_email(e: &api::EmailResult) -> Email {
 #[component]
 pub fn EmailList() -> Element {
     let navigator = use_navigator();
-    let mut manual_query = use_signal(String::new);
 
     // Load classifiers once on mount so pill taps can use their terms.
     use_effect(move || {
@@ -133,9 +132,8 @@ pub fn EmailList() -> Element {
             }
 
             SearchBar {
-                value: manual_query(),
+                value: EMAIL_LIST_QUERY(),
                 on_change: move |v: String| {
-                    manual_query.set(v.clone());
                     // When the user types, reset filter to All so the manual
                     // query drives search without category restriction.
                     if EMAIL_LIST_FILTER() != "All" {
@@ -151,11 +149,10 @@ pub fn EmailList() -> Element {
                 active: EMAIL_LIST_FILTER(),
                 on_change: move |v: String| {
                     *EMAIL_LIST_FILTER.write() = v.clone();
-                    if v == "All" {
-                        // Restore whatever the user had typed manually.
-                        *EMAIL_LIST_QUERY.write() = manual_query();
-                    } else if let Some(q) = query_from_classifier(&v) {
-                        *EMAIL_LIST_QUERY.write() = q;
+                    if v != "All" {
+                        if let Some(q) = query_from_classifier(&v) {
+                            *EMAIL_LIST_QUERY.write() = q;
+                        }
                     }
                 },
             }

--- a/src/views/email_list.rs
+++ b/src/views/email_list.rs
@@ -9,7 +9,7 @@ use crate::components::filter_chips::FilterChips;
 use crate::components::search_bar::SearchBar;
 use crate::types::{Category, Email};
 use crate::Route;
-use crate::{EMAIL_LIST_FILTER, EMAIL_LIST_QUERY, SELECTED_EMAIL};
+use crate::{CLASSIFIERS, EMAIL_LIST_FILTER, EMAIL_LIST_QUERY, SELECTED_EMAIL};
 
 fn filter_matches(category: &Category, active_filter: &str) -> bool {
     match active_filter {
@@ -20,6 +20,30 @@ fn filter_matches(category: &Category, active_filter: &str) -> bool {
         "Other" => *category == Category::Other || *category == Category::Activity,
         _ => true, // "All"
     }
+}
+
+/// Map a filter-chip label to the classifier category key used by the backend.
+fn pill_to_classifier_key(pill: &str) -> Option<&'static str> {
+    match pill {
+        "Flights ✈️" => Some("flights"),
+        "Hotels 🏨" => Some("hotels"),
+        "Car Rental 🚗" => Some("car_rental"),
+        "Cruises 🚢" => Some("cruises"),
+        "Other" => Some("other"),
+        _ => None,
+    }
+}
+
+/// Build a search query from a classifier category's subject keywords.
+fn query_from_classifier(filter: &str) -> Option<String> {
+    let key = pill_to_classifier_key(filter)?;
+    let classifiers = CLASSIFIERS();
+    let cfg = classifiers.as_ref()?;
+    let rule = cfg.categories.get(key)?;
+    if rule.subject_keywords.is_empty() {
+        return None;
+    }
+    Some(rule.subject_keywords.join(" OR "))
 }
 
 fn to_ui_email(e: &api::EmailResult) -> Email {
@@ -39,6 +63,18 @@ fn to_ui_email(e: &api::EmailResult) -> Email {
 #[component]
 pub fn EmailList() -> Element {
     let navigator = use_navigator();
+    let mut manual_query = use_signal(String::new);
+
+    // Load classifiers once on mount so pill taps can use their terms.
+    use_effect(move || {
+        if CLASSIFIERS().is_none() {
+            spawn(async move {
+                if let Ok(cfg) = api::get_classifiers().await {
+                    *CLASSIFIERS.write() = Some(cfg);
+                }
+            });
+        }
+    });
 
     let emails_resource = use_resource(move || {
         let query = EMAIL_LIST_QUERY();
@@ -97,15 +133,31 @@ pub fn EmailList() -> Element {
             }
 
             SearchBar {
-                value: EMAIL_LIST_QUERY(),
-                on_change: move |v: String| *EMAIL_LIST_QUERY.write() = v,
+                value: manual_query(),
+                on_change: move |v: String| {
+                    manual_query.set(v.clone());
+                    // When the user types, reset filter to All so the manual
+                    // query drives search without category restriction.
+                    if EMAIL_LIST_FILTER() != "All" {
+                        *EMAIL_LIST_FILTER.write() = "All".to_string();
+                    }
+                    *EMAIL_LIST_QUERY.write() = v;
+                },
             }
 
             DiscoveryBanner { count: discovery_count() }
 
             FilterChips {
                 active: EMAIL_LIST_FILTER(),
-                on_change: move |v: String| *EMAIL_LIST_FILTER.write() = v,
+                on_change: move |v: String| {
+                    *EMAIL_LIST_FILTER.write() = v.clone();
+                    if v == "All" {
+                        // Restore whatever the user had typed manually.
+                        *EMAIL_LIST_QUERY.write() = manual_query();
+                    } else if let Some(q) = query_from_classifier(&v) {
+                        *EMAIL_LIST_QUERY.write() = q;
+                    }
+                },
             }
 
             div { class: "flex-1 overflow-y-auto py-2 pb-4",

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -36,6 +36,7 @@ pub fn Settings() -> Element {
     let mut classifier_saving = use_signal(|| false);
     let mut classifiers = use_signal(|| ClassifiersConfig {
         categories: HashMap::new(),
+        category_titles: HashMap::new(),
     });
     let mut new_category = use_signal(String::new);
 
@@ -165,13 +166,19 @@ pub fn Settings() -> Element {
                                 div { class: "flex flex-col gap-3",
                                     for category in category_names {
                                         {
-                                            let rule = classifiers().categories.get(&category).cloned().unwrap_or(CategoryRule { domains: vec![], subject_keywords: vec![] });
+                                            let cfg_snapshot = classifiers();
+                                            let rule = cfg_snapshot.categories.get(&category).cloned().unwrap_or(CategoryRule { domains: vec![], subject_keywords: vec![] });
+                                            let category_title = cfg_snapshot
+                                                .category_titles
+                                                .get(&category)
+                                                .cloned()
+                                                .unwrap_or_else(|| category.replace('_', " "));
                                             let domains_csv = to_csv(&rule.domains);
                                             let keywords_csv = to_csv(&rule.subject_keywords);
                                             rsx! {
                                                 div { key: "{category}", class: "border border-border rounded-lg p-3",
                                                     div { class: "flex items-center justify-between mb-2",
-                                                        h3 { class: "font-semibold text-foreground", "{category}" }
+                                                        h3 { class: "font-semibold text-foreground", "{category_title}" }
                                                         button {
                                                             class: "text-xs text-red-400",
                                                             onclick: {

--- a/src/views/settings.rs
+++ b/src/views/settings.rs
@@ -1,5 +1,10 @@
+use std::collections::HashMap;
+
 use dioxus::prelude::*;
 
+use crate::api::{
+    get_classifiers, reset_classifiers, update_classifiers, CategoryRule, ClassifiersConfig,
+};
 use crate::components::app_header::AppHeader;
 use crate::components::bottom_nav::BottomNavBar;
 use crate::components::button::Button;
@@ -7,12 +12,42 @@ use crate::components::input::Input;
 use crate::config::{save_config, validate_server, APP_CONFIG};
 use crate::notification::{notify_error, notify_success};
 
+fn parse_csv(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn to_csv(items: &[String]) -> String {
+    items.join(", ")
+}
+
 #[component]
 pub fn Settings() -> Element {
     let config = APP_CONFIG();
     let mut server_url = use_signal(|| config.server_url.clone());
     let mut api_key = use_signal(|| config.api_key.clone());
     let mut loading = use_signal(|| false);
+
+    let mut classifier_loading = use_signal(|| true);
+    let mut classifier_saving = use_signal(|| false);
+    let mut classifiers = use_signal(|| ClassifiersConfig {
+        categories: HashMap::new(),
+    });
+    let mut new_category = use_signal(String::new);
+
+    use_effect(move || {
+        spawn(async move {
+            match get_classifiers().await {
+                Ok(cfg) => classifiers.set(cfg),
+                Err(e) => notify_error(format!("Failed to load classifiers: {e}")),
+            }
+            classifier_loading.set(false);
+        });
+    });
 
     let masked_key = {
         let key = config.api_key.clone();
@@ -25,7 +60,7 @@ pub fn Settings() -> Element {
         }
     };
 
-    let on_save = move |_| {
+    let on_save_connection = move |_| {
         spawn(async move {
             let url = server_url();
             let key = api_key();
@@ -39,11 +74,38 @@ pub fn Settings() -> Element {
                     save_config(&url, &key).await;
                     notify_success("Connected successfully!");
                 }
-                Err(e) => {
-                    notify_error(format!("Connection failed: {e}"));
-                }
+                Err(e) => notify_error(format!("Connection failed: {e}")),
             }
             loading.set(false);
+        });
+    };
+
+    let on_save_classifiers = move |_| {
+        spawn(async move {
+            classifier_saving.set(true);
+            let cfg = classifiers();
+            match update_classifiers(&cfg).await {
+                Ok(saved) => {
+                    classifiers.set(saved);
+                    notify_success("Classifier settings saved");
+                }
+                Err(e) => notify_error(format!("Failed to save classifiers: {e}")),
+            }
+            classifier_saving.set(false);
+        });
+    };
+
+    let on_reset_classifiers = move |_| {
+        spawn(async move {
+            classifier_saving.set(true);
+            match reset_classifiers().await {
+                Ok(defaults) => {
+                    classifiers.set(defaults);
+                    notify_success("Classifier settings reset to defaults");
+                }
+                Err(e) => notify_error(format!("Failed to reset classifiers: {e}")),
+            }
+            classifier_saving.set(false);
         });
     };
 
@@ -63,9 +125,7 @@ pub fn Settings() -> Element {
                                 r#type: "url",
                                 placeholder: "https://your-server.example.com",
                                 value: "{server_url}",
-                                oninput: move |e: FormEvent| {
-                                    server_url.set(e.value());
-                                },
+                                oninput: move |e: FormEvent| server_url.set(e.value()),
                             }
                         }
                         div { class: "flex flex-col gap-1",
@@ -77,21 +137,134 @@ pub fn Settings() -> Element {
                                 r#type: "password",
                                 placeholder: "Enter new API key",
                                 value: "{api_key}",
-                                oninput: move |e: FormEvent| {
-                                    api_key.set(e.value());
-                                },
+                                oninput: move |e: FormEvent| api_key.set(e.value()),
                             }
                         }
                     }
 
                     div { class: "mt-4",
                         Button {
-                            onclick: on_save,
+                            onclick: on_save_connection,
                             class: "w-full bg-cta text-white rounded-lg py-3 font-semibold",
-                            if loading() {
-                                "Connecting..."
-                            } else {
-                                "Save & Connect"
+                            if loading() { "Connecting..." } else { "Save & Connect" }
+                        }
+                    }
+                }
+
+                div { class: "bg-card rounded-xl border border-border p-4 mb-4",
+                    h2 { class: "text-lg font-semibold text-foreground mb-1", "Classifier Rules" }
+                    p { class: "text-sm text-muted mb-4", "Edit domains and subject keywords per category. Use comma-separated values." }
+
+                    if classifier_loading() {
+                        p { class: "text-sm text-muted", "Loading classifier settings..." }
+                    } else {
+                        {
+                            let mut category_names = classifiers().categories.keys().cloned().collect::<Vec<_>>();
+                            category_names.sort();
+                            rsx! {
+                                div { class: "flex flex-col gap-3",
+                                    for category in category_names {
+                                        {
+                                            let rule = classifiers().categories.get(&category).cloned().unwrap_or(CategoryRule { domains: vec![], subject_keywords: vec![] });
+                                            let domains_csv = to_csv(&rule.domains);
+                                            let keywords_csv = to_csv(&rule.subject_keywords);
+                                            rsx! {
+                                                div { key: "{category}", class: "border border-border rounded-lg p-3",
+                                                    div { class: "flex items-center justify-between mb-2",
+                                                        h3 { class: "font-semibold text-foreground", "{category}" }
+                                                        button {
+                                                            class: "text-xs text-red-400",
+                                                            onclick: {
+                                                                let category = category.clone();
+                                                                move |_| {
+                                                                    let mut cfg = classifiers();
+                                                                    cfg.categories.remove(&category);
+                                                                    classifiers.set(cfg);
+                                                                }
+                                                            },
+                                                            "Remove"
+                                                        }
+                                                    }
+
+                                                    div { class: "mb-2",
+                                                        label { class: "text-xs text-muted", "Domains" }
+                                                        Input {
+                                                            r#type: "text",
+                                                            placeholder: "delta.com, united.com",
+                                                            value: "{domains_csv}",
+                                                            oninput: {
+                                                                let category = category.clone();
+                                                                move |e: FormEvent| {
+                                                                    let mut cfg = classifiers();
+                                                                    let entry = cfg.categories.entry(category.clone()).or_insert(CategoryRule { domains: vec![], subject_keywords: vec![] });
+                                                                    entry.domains = parse_csv(&e.value());
+                                                                    classifiers.set(cfg);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                    div {
+                                                        label { class: "text-xs text-muted", "Subject keywords" }
+                                                        Input {
+                                                            r#type: "text",
+                                                            placeholder: "boarding pass, itinerary",
+                                                            value: "{keywords_csv}",
+                                                            oninput: {
+                                                                let category = category.clone();
+                                                                move |e: FormEvent| {
+                                                                    let mut cfg = classifiers();
+                                                                    let entry = cfg.categories.entry(category.clone()).or_insert(CategoryRule { domains: vec![], subject_keywords: vec![] });
+                                                                    entry.subject_keywords = parse_csv(&e.value());
+                                                                    classifiers.set(cfg);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        div { class: "mt-4 border-t border-border pt-4",
+                            label { class: "text-xs text-muted", "Add category" }
+                            div { class: "flex gap-2 mt-1",
+                                Input {
+                                    r#type: "text",
+                                    placeholder: "example: train",
+                                    value: "{new_category}",
+                                    oninput: move |e: FormEvent| new_category.set(e.value()),
+                                }
+                                Button {
+                                    class: "px-4",
+                                    onclick: move |_| {
+                                        let name = new_category().trim().to_lowercase().replace(' ', "_");
+                                        if name.is_empty() {
+                                            return;
+                                        }
+                                        let mut cfg = classifiers();
+                                        cfg.categories.entry(name).or_insert(CategoryRule { domains: vec![], subject_keywords: vec![] });
+                                        classifiers.set(cfg);
+                                        new_category.set(String::new());
+                                    },
+                                    "Add"
+                                }
+                            }
+                        }
+
+                        div { class: "mt-4 flex gap-2",
+                            Button {
+                                onclick: on_save_classifiers,
+                                class: "flex-1 bg-cta text-white rounded-lg py-3 font-semibold",
+                                if classifier_saving() { "Saving..." } else { "Save Classifiers" }
+                            }
+                            Button {
+                                onclick: on_reset_classifiers,
+                                class: "flex-1 rounded-lg py-3 font-semibold",
+                                "Reset to Defaults"
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
Implements classifier settings in the app Settings screen for issue #54.

## What's included
- Adds API client support for classifier config endpoints:
  - `get_classifiers()`
  - `update_classifiers()`
  - `reset_classifiers()`
- Regenerates transport types from backend swagger
- Adds a new **Classifier Rules** settings card:
  - Loads current classifier config
  - Edit domains + subject keywords per category (comma-separated)
  - Add/remove categories
  - Save changes with success/error feedback
  - Reset to defaults action

## Build
- `dx build --platform web` succeeds locally

Depends on backend PR: https://github.com/zachatrocity/voyage-backend/pull/39
Closes #54
